### PR TITLE
Add date colours

### DIFF
--- a/app/datetime/DateUtils.scala
+++ b/app/datetime/DateUtils.scala
@@ -1,13 +1,33 @@
 package datetime
 
-import org.joda.time.DateTime
+import play.api.Logger
+import org.joda.time.{Days, DateTime}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import play.api.libs.json.{Format, Writes, Reads}
 
+//case class DateWithWarning(dateString: String, status: PeriodStatus)
+
 object DateUtils {
+  def getAgeColour(date: DateTime) = {
+    val days = daysAgo(date)
+    if (days < 0 ) {
+      Logger.error("AMI cannot be from the future!")
+      "black"
+    }
+    else {
+      if (days < 7) "green"
+      else if (days < 30) "amber"
+      else "red"
+    }
+  }
+
   implicit val isoDateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   implicit val isoDateWrites = Writes.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   implicit val jodaDateTimeFormats = Format[DateTime](isoDateReads, isoDateWrites)
   val yearMonthDay: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
   val yearMonthDayTime: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm")
+  val readableDateTime: DateTimeFormatter = DateTimeFormat.forPattern("dd MMMM yyyy 'at' HH:mm")
+
+  def daysAgo(date:DateTime): Int = Days.daysBetween(date, DateTime.now).getDays
+
 }

--- a/app/views/ami.scala.html
+++ b/app/views/ami.scala.html
@@ -14,7 +14,16 @@
                 <dt>Description</dt>
                 <dd>@ami.description</dd>
                 <dt>Creation date</dt>
-                <dd>@ami.creationDate.fold("Too old")(datetime.DateUtils.yearMonthDayTime.print(_))</dd>
+                @*<dd>@ami.creationDate.fold("Too old")(datetime.DateUtils.readableDateTime.print(_) + s" - ${datetime.DateUtils.daysAgo(_)} days ago")</dd>*@
+                <dd>@ami.creationDate match {
+                    case Some(date) => {
+                        @datetime.DateUtils.readableDateTime.print(date) -
+                        <span class="@datetime.DateUtils.getAgeColour(date)">@datetime.DateUtils.daysAgo(date) days old</span>
+                    }
+                    case None => {
+                        Too old
+                    }
+                }</dd>
                 <dt>ARN</dt>
                 <dd>@ami.arn</dd>
             </dl>

--- a/app/views/amis.scala.html
+++ b/app/views/amis.scala.html
@@ -19,7 +19,15 @@
                         <dt>Description</dt>
                         <dd>@ami.description.getOrElse("No description available")</dd>
                         <dt>Creation date</dt>
-                        <dd>@ami.creationDate.getOrElse("Too old to say")</dd>
+                        <dd>@ami.creationDate match {
+                            case Some(date) => {
+                                @datetime.DateUtils.readableDateTime.print(date) -
+                                <span class="@datetime.DateUtils.getAgeColour(date)">@datetime.DateUtils.daysAgo(date) days old</span>
+                            }
+                            case None => {
+                                Too old
+                            }
+                        }</dd>
                         <dt>ARN</dt>
                         <dd>@ami.arn</dd>
                     </dl>

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -18,7 +18,15 @@
                     <dt>Description</dt>
                     <dd>@ami.description.getOrElse("No description available")</dd>
                     <dt>Creation date</dt>
-                    <dd>@ami.creationDate.fold("Too old")(datetime.DateUtils.yearMonthDayTime.print(_))</dd>
+                    <dd>@ami.creationDate match {
+                        case Some(date) => {
+                            @datetime.DateUtils.readableDateTime.print(date) -
+                            <span class="@datetime.DateUtils.getAgeColour(date)">@datetime.DateUtils.daysAgo(date) days old</span>
+                        }
+                        case None => {
+                            Too old
+                        }
+                    }</dd>
                     <dt>ARN</dt>
                     <dd>@ami.arn</dd>
                 </dl>

--- a/test/datetime/DateUtilsTest.scala
+++ b/test/datetime/DateUtilsTest.scala
@@ -1,0 +1,24 @@
+package datetime
+
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+import DateUtils._
+
+class DateUtilsTest extends FreeSpec with Matchers {
+
+  "daysAgo" - {
+    "should correctly calculate how long ago a date was" in {
+      daysAgo(DateTime.now.minusDays(5)) shouldEqual 5
+    }
+  }
+
+  "periodStatus" - {
+    "should mark 500 as status red" in {
+      periodStatus(500) shouldEqual Some("Red")
+    }
+
+    "should return none for negative values" in {
+      periodStatus(-50) shouldEqual None
+    }
+  }
+}


### PR DESCRIPTION
Makes dates pretty print, with the number of days since an AMI was created highlighted in red/amber/green.

Could do with some refactoring to avoid the repeated template code