### PR TITLE
Add analytics to homepage

### DIFF
--- a/app/models/Serialisation.scala
+++ b/app/models/Serialisation.scala
@@ -4,6 +4,7 @@ import play.api.libs.json.Json
 
 object Serialisation {
   import datetime.DateUtils._
+
   implicit val originFormat = Json.format[Origin]
   implicit val metaFormat = Json.format[Meta]
   implicit val instanceFormat = Json.format[Instance]

--- a/app/prism/PrismLogic.scala
+++ b/app/prism/PrismLogic.scala
@@ -1,0 +1,42 @@
+package prism
+
+import datetime.DateUtils
+import models._
+
+object PrismLogic {
+  def oldInstances(instanceAmis: Map[Instance, Option[AMI]]): List[Instance] = {
+    instanceAmis.toList
+      .filter { case (_, amiOpt) => amiOpt.exists(amiIsOld) }
+      .map(_._1)
+  }
+
+  def stacks(instances: List[Instance]): List[String] = {
+    (for {
+      instance <- instances
+      stack <- instance.stack
+    } yield stack).distinct
+  }
+
+  def amiArns(instances: List[Instance]): List[String] =
+    instances.flatMap(_.amiArn).distinct
+
+  /**
+    * Associates instances with their AMI
+    */
+  def instanceAmis(instances: List[Instance], amis: List[AMI]): Map[Instance, Option[AMI]] = {
+    instances.map { instance =>
+      instance -> instance.amiArn.flatMap { amiArn =>
+        amis.find(_.arn == amiArn)
+      }
+    }.toMap
+  }
+
+  def amiIsOld(ami: AMI): Boolean = {
+    ami.creationDate.flatMap { creationDate =>
+      DateUtils.getAge(creationDate).map {
+        case Fresh | Turning => false
+        case _ => true
+      }
+    }.getOrElse(true)
+  }
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@()
+@(oldInstances: List[Instance], oldStacks: List[String])
 
 @import views.html.fragments.ssaAmiForm
 
@@ -8,10 +8,20 @@
             <h1 class="hide">AMIable</h1>
             <div class="row">
                 <div class="col m6">
-                    <p>TODO: Number of apps with old AMIs</p>
+                    <p class="grey-text darken-1">
+                        Instances running on an out-of-date AMI
+                    </p>
+                    <div class="old-instance-count deep-purple-text">
+                        @oldInstances.size
+                    </div>
                 </div>
                 <div class="col m6">
-                    <p>TODO: SSAs with old AMIs</p>
+                    <p class="grey-text darken-1">
+                        Stacks running old AMIs
+                    </p>
+                    @for(stack <- oldStacks) {
+                        <div class="chip"><a href="/instanceAMIs?stack=@stack">@stack</a></div>
+                    }
                 </div>
             </div>
         </div>

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -31,7 +31,7 @@
                         </div>
                     }
                     case Right(ami) => {
-                        @formatAmi(ami)
+                        @formatAmi(ami, amis.size > 1)
                     }
                 }
             </div>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -22,6 +22,11 @@ h1 {
     margin-bottom: 1em;
 }
 
+.old-instance-count {
+    margin: 20px 0 5px 0;
+    font-size:10rem;
+}
+
 #logo-container img {
     vertical-align: middle;
     margin-top: -5px;

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -1,0 +1,91 @@
+package prism
+
+import models.{AMI, Instance}
+import org.joda.time.DateTime
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
+
+
+class PrismLogicTest extends FreeSpec with Matchers with MockitoSugar with OneInstancePerTest {
+  import prism.PrismLogic._
+
+  val (i1, i2, i3, i4, i5) = (mock[Instance], mock[Instance], mock[Instance], mock[Instance], mock[Instance])
+  val (a1, a2, a3, a4, a5) = (mock[AMI], mock[AMI], mock[AMI], mock[AMI], mock[AMI])
+
+  "oldInstances" - {
+    when(a1.creationDate).thenReturn(Some(DateTime.now.minusDays(1)))
+    when(a2.creationDate).thenReturn(Some(DateTime.now.minusDays(40)))
+
+    "returns old instances" in {
+      oldInstances(Map(i1 -> Some(a1), i2 -> Some(a2))) should contain(i2)
+    }
+
+    "excludes young instances" in {
+      oldInstances(Map(i1 -> Some(a1), i2 -> Some(a2))) shouldNot contain(i1)
+    }
+  }
+
+  "stacks" - {
+    "dedupes stacks" in {
+      when(i1.stack).thenReturn(Some("stack"))
+      when(i2.stack).thenReturn(Some("stack"))
+      stacks(List(i1, i2)) shouldEqual List("stack")
+    }
+
+    "returns the correct stacks for these instances" in {
+      when(i1.stack).thenReturn(Some("stack1"))
+      when(i2.stack).thenReturn(Some("stack2"))
+      when(i3.stack).thenReturn(Some("stack2"))
+      when(i4.stack).thenReturn(Some("stack3"))
+      when(i5.stack).thenReturn(None)
+      stacks(List(i1, i2, i3, i4, i5)) shouldEqual List("stack1", "stack2", "stack3")
+    }
+  }
+
+  "amiArns" - {
+    when(i1.amiArn).thenReturn(Some("arn-1"))
+    when(i2.amiArn).thenReturn(Some("arn-1"))
+    when(i3.amiArn).thenReturn(Some("arn-2"))
+    when(i4.amiArn).thenReturn(Some("arn-3"))
+    when(i5.amiArn).thenReturn(None)
+
+    "dedupes ARNs" in {
+      amiArns(List(i1, i2)) shouldEqual List("arn-1")
+    }
+
+    "returns the correct ARNs for these instances" in {
+      amiArns(List(i1, i2, i3, i4, i5)) shouldEqual List("arn-1", "arn-2", "arn-3")
+    }
+  }
+
+  "instanceAmis" - {
+    when(a1.arn).thenReturn("arn-1")
+    when(i1.amiArn).thenReturn(Some("arn-1"))
+    when(i2.amiArn).thenReturn(Some("arn-1"))
+
+    "associates an instance with its AMI" in {
+      instanceAmis(List(i1), List(a1)) shouldEqual Map(i1 -> Some(a1))
+    }
+
+    "associates instance with None if its AMI is not present" in {
+      instanceAmis(List(i1), Nil) shouldEqual Map(i1 -> None)
+    }
+
+    "associates multiple instances with a shared AMI" in {
+      instanceAmis(List(i1, i2), List(a1)) shouldEqual Map(i1 -> Some(a1), i2 -> Some(a1))
+    }
+  }
+
+  "amiIsOld" - {
+    "returns false for a fresh AMI" in {
+      when(a1.creationDate).thenReturn(Some(DateTime.now.minusDays(1)))
+      amiIsOld(a1) shouldEqual false
+    }
+
+    "returns true for an ageing AMI" in {
+      when(a1.creationDate).thenReturn(Some(DateTime.now.minusDays(40)))
+      amiIsOld(a1) shouldEqual true
+    }
+  }
+}


### PR DESCRIPTION
Generate more useful insights from the data by working out the number of affected PROD instances and the stacks where they live.

This implements the TODOs on the homepage as well as a couple of other teeny tidies that change touched.