### PR TITLE
More helpful ami display

### DIFF
--- a/app/controllers/AMIable.scala
+++ b/app/controllers/AMIable.scala
@@ -58,10 +58,11 @@ class AMIable extends Controller {
       for {
         instances <- Prism.getInstances(ssa)
         amiArns = instances.flatMap(_.amiArn).distinct
-        amiAttempts <- Attempt.sequenceFutures(amiArns.map(Prism.getAMI))
-        amiOrError = amiAttempts.map(_.left.map(_.errors.map(_.friendlyMessage).mkString(", ")))
+        amis <- Attempt.successfulAttempts(amiArns.map(Prism.getAMI))
+        amisWithInstances = PrismLogic.amiInstances(amis, instances)
+        amiSSAs = PrismLogic.amiSSAs(amisWithInstances)
       } yield {
-        Ok(views.html.instanceAMIs(ssa.stack, ssa.stage, ssa.app, amiOrError))
+        Ok(views.html.instanceAMIs(ssa.stack, ssa.stage, ssa.app, PrismLogic.sortSSAAmisByAge(amiSSAs)))
       }
     }
   }

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -72,6 +72,7 @@ case class SSA (
   stage: Option[String] = None,
   app: Option[String] = None
 ) {
+  def isEmpty = stack.isEmpty && stage.isEmpty && app.isEmpty
   override def toString: String = s"SSA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}>"
 }
 object SSA {

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -71,7 +71,9 @@ case class SSA (
   stack: Option[String] = None,
   stage: Option[String] = None,
   app: Option[String] = None
-)
+) {
+  override def toString: String = s"SSA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}>"
+}
 object SSA {
   /**
     * Filters empty strings to None, such as those provided by request parameters.

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -63,6 +63,19 @@ case class Origin(
   accountNumber: String
 )
 
+case class SSA (
+  stack: Option[String] = None,
+  stage: Option[String] = None,
+  app: Option[String] = None
+)
+object SSA {
+  /**
+    * Filters empty strings to None, such as those provided by request parameters.
+    */
+  def fromParams(stack: Option[String] = None, stage: Option[String] = None, app: Option[String] = None): SSA =
+    SSA(stack.filter(_.nonEmpty), stage.filter(_.nonEmpty), app.filter(_.nonEmpty))
+}
+
 case class AMIableError(
   message: String,
   friendlyMessage: String,

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -22,7 +22,9 @@ case class AMI(
   virtualizationType: String,
   hypervisor: String,
   sriovNetSupport: Option[String]
-)
+) {
+  override def toString: String = s"AMI<$arn>"
+}
 object AMI {
   import datetime.DateUtils._
   implicit val jsonFormat = Json.format[AMI]
@@ -49,6 +51,8 @@ case class Instance(
   meta: Meta
 ) {
   val amiArn = specification.get("imageArn")
+
+  override def toString: String = s"Instance<$arn>"
 }
 
 case class Meta(

--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -37,7 +37,7 @@ object Prism {
     } yield instances
   }
 
-  def instancesWithAmis(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[Map[Instance, Option[AMI]]] = {
+  def instancesWithAmis(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[(Instance, Option[AMI])]] = {
     for {
       prodInstances <- getInstances(stackStageApp)
       amiAttempts = amiArns(prodInstances).map(getAMI)

--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -28,9 +28,8 @@ object Prism {
     } yield amis
   }
 
-  def getInstances(stack: Option[String] = None, stage: Option[String] = None, app: Option[String] = None)
-                  (implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[Instance]] = {
-    val url = instancesUrl(stack, stage, app, config.prismUrl)
+  def getInstances(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[Instance]] = {
+    val url = instancesUrl(stackStageApp, config.prismUrl)
     for {
       response <- Http.response(config.wsClient.url(url).get(), "Unable to fetch instance", url)
       jsons <- instancesResponseJson(response)
@@ -38,10 +37,9 @@ object Prism {
     } yield instances
   }
 
-  def instancesWithAmis(stack: Option[String] = None, stage: Option[String] = None, app: Option[String] = None)
-                       (implicit config: AMIableConfig, ec: ExecutionContext): Attempt[Map[Instance, Option[AMI]]] = {
+  def instancesWithAmis(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[Map[Instance, Option[AMI]]] = {
     for {
-      prodInstances <- getInstances(stack, stage, app)
+      prodInstances <- getInstances(stackStageApp)
       amiAttempts = amiArns(prodInstances).map(getAMI)
       amis <- Attempt.successfulAttempts(amiAttempts)
     } yield instanceAmis(prodInstances, amis)

--- a/app/prism/PrismLogic.scala
+++ b/app/prism/PrismLogic.scala
@@ -73,7 +73,8 @@ object PrismLogic {
   }
 
   /**
-    * Put AMIs without an SSA last
+    * SSAs are sorted by their oldest AMI, except for the empty SSA which
+    * always appears last.
     */
   def sortSSAAmisByAge(ssaAmis: Map[SSA, List[AMI]]): List[(SSA, List[AMI])] = {
     ssaAmis.toList.sortBy { case (ssa, amis) =>

--- a/app/prism/PrismLogic.scala
+++ b/app/prism/PrismLogic.scala
@@ -2,6 +2,7 @@ package prism
 
 import datetime.DateUtils
 import models._
+import org.joda.time.DateTime
 
 object PrismLogic {
   def oldInstances(instanceAmis: List[(Instance, Option[AMI])]): List[Instance] = {
@@ -71,13 +72,21 @@ object PrismLogic {
       }
   }
 
+  /**
+    * Put AMIs without an SSA last
+    */
   def sortSSAAmisByAge(ssaAmis: Map[SSA, List[AMI]]): List[(SSA, List[AMI])] = {
-    ssaAmis.toList.sortBy { case (_, amis) =>
-      val creationDates = for {
-        ami <- amis
-        creationDate <- ami.creationDate
-      } yield creationDate.getMillis
-      creationDates.headOption.getOrElse(0L)
+    ssaAmis.toList.sortBy { case (ssa, amis) =>
+      if (ssa.isEmpty) {
+        // put empty SSA last
+        DateTime.now.getMillis
+      } else {
+        val creationDates = for {
+          ami <- amis
+          creationDate <- ami.creationDate
+        } yield creationDate.getMillis
+        creationDates.headOption.getOrElse(0L)
+      }
     }
   }
 

--- a/app/prism/Urls.scala
+++ b/app/prism/Urls.scala
@@ -2,6 +2,8 @@ package prism
 
 import java.net.URLEncoder
 
+import models.SSA
+
 
 object Urls {
   def amiUrl(arn: String, prismUrl: String): String = {
@@ -15,9 +17,9 @@ object Urls {
 
   private[prism] def emptyToNone(strOpt: Option[String]) = strOpt.filter(_.nonEmpty)
 
-  def instancesUrl(stack: Option[String], stage: Option[String], app: Option[String], prismUrl: String) = {
+  def instancesUrl(ssa: SSA, prismUrl: String) = {
     val getVars = for {
-      (name, strOpt) <- List("stack" -> emptyToNone(stack), "stage" -> emptyToNone(stage), "app" -> emptyToNone(app))
+      (name, strOpt) <- List("stack" -> ssa.stack, "stage" -> ssa.stage, "app" -> ssa.app)
       getVar <- strOpt.map(str =>  s"$name=${URLEncoder.encode(str, "UTF-8")}")
     } yield getVar
     s"$prismUrl/instances?${getVars.mkString("&")}"

--- a/app/views/fragments/formatAmi.scala.html
+++ b/app/views/fragments/formatAmi.scala.html
@@ -8,9 +8,13 @@
             <img src="/assets/images/ami.png" alt="AMI" class="ami-badge__icon">
         </div>
         <div class="ami-badge__description center-align">
-            <a class="modal-trigger" href="#modal-@id">
+            @if(listDisplay) {
+                <a class="modal-trigger" href="#modal-@id">
+            }
                 @ami.imageId
-            </a>
+            @if(listDisplay) {
+                </a>
+            }
         </div>
         <div class="ami-badge__age @colour white-text center-align">
             @ami.creationDate match {

--- a/app/views/fragments/formatAmi.scala.html
+++ b/app/views/fragments/formatAmi.scala.html
@@ -3,15 +3,26 @@
 @import datetime.DateUtils.{readableDateTime, getAgeColour, daysAgo}
 
 @defining(ami.creationDate.map(getAgeColour).getOrElse("red")) { colour =>
-    <div class="ami-badge card-panel @colour darken-3 center-align">
-        @if(listDisplay){
-            <a class="modal-trigger white-text" href="#modal-@id">
-        }
-                <img src="/assets/images/ami.png" alt="AMI" class="ami-icon z-depth-1">
+    <div class="ami-badge z-depth-1 grey lighten-3">
+        <div class="ami-badge__icon-container">
+            <img src="/assets/images/ami.png" alt="AMI" class="ami-badge__icon">
+        </div>
+        <div class="ami-badge__description center-align">
+            <a class="modal-trigger" href="#modal-@id">
                 @ami.imageId
-        @if(listDisplay){
             </a>
-        }
+        </div>
+        <div class="ami-badge__age @colour white-text center-align">
+            @ami.creationDate match {
+                case Some(date) => {
+                    @daysAgo(date)
+                    <i class="mdi-image-timelapse"></i>
+                }
+                case None => {
+                    Ancient
+                }
+            }
+        </div>
     </div>
 }
 

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,0 +1,11 @@
+@(ssa: SSA)
+
+@ssa.stack.map { stack =>
+    <span class="chip">@stack</span>
+}
+@ssa.stage.map { stage =>
+    <span class="chip">@stage</span>
+}
+@ssa.app.map { app =>
+    <span class="chip">@app</span>
+}

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,11 +1,15 @@
 @(ssa: SSA)
 
-@ssa.stack.map { stack =>
-    <span class="chip">@stack</span>
-}
-@ssa.stage.map { stage =>
-    <span class="chip">@stage</span>
-}
-@ssa.app.map { app =>
-    <span class="chip">@app</span>
+@if(ssa.isEmpty) {
+    No stack/stage/app
+} else {
+    @ssa.stack.map { stack =>
+        <span class="chip">@stack</span>
+    }
+    @ssa.stage.map { stage =>
+        <span class="chip">@stage</span>
+    }
+    @ssa.app.map { app =>
+        <span class="chip">@app</span>
+    }
 }

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -1,41 +1,23 @@
-@(stack: Option[String], stage: Option[String], app: Option[String], amis: List[Either[String, AMI]])
+@(stack: Option[String], stage: Option[String], app: Option[String], amiSSAs: List[(SSA, scala.List[AMI])])
 
-@import views.html.fragments.{ssaAmiForm, formatAmi, heading}
+@import views.html.fragments.{ssaAmiForm, formatAmi, heading, printSSA}
 
 @main("Instance AMIs") {
     @heading("AMIs in use")
     <div class="container">
-        <p>
-            @stack.map { stack =>
-                <span class="chip">@stack</span>
-            }
-            @stage.map { stage =>
-                <span class="chip">@stage</span>
-            }
-            @app.map { app =>
-                <span class="chip">@app</span>
-            }
-        </p>
         <div class="row">
-            @for((amiOrError, i) <- amis.zipWithIndex) {
-                @if((i % 3) == 0 && i > 0) {
-                </div>
-        <div class="row">
-        }
-            <div class="col m4">
-                @amiOrError match {
-                    case Left(err) => {
-                        <div class="ami-badge card-panel grey darken-3 center-align white-text">
-                            <img src="/assets/images/ami-error.png" alt="AMI" class="ami-icon z-depth-2">
-                            @err
+            @for((ssa, amis) <- amiSSAs) {
+                <div class="col m4">
+                    <div class="card">
+                        <div class="card-content">
+                            @printSSA(ssa)
+                            @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
+                                @formatAmi(ami)
+                            }
                         </div>
-                    }
-                    case Right(ami) => {
-                        @formatAmi(ami, amis.size > 1)
-                    }
-                }
-            </div>
-        }
+                    </div>
+                </div>
+            }
         </div>
         @ssaAmiForm(stack, stage, app)
     </div>

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -5,19 +5,41 @@
 @main("Instance AMIs") {
     @heading("AMIs in use")
     <div class="container">
-        <div class="ssa-amis">
-            @for((ssa, amis) <- amiSSAs) {
-                <div class="ssa-amis__item">
-                    <div class="card">
-                        <div class="card-content">
+        <div class="row">
+            <div class="ssa-amis">
+                @for((ssa, amis) <- amiSSAs) {
+                    @if(ssa.isEmpty) {
+                        @* show AMIs with empty SSAs in their own block (there are lots of them) *@
+            </div>
+        </div>
+
+        <div class="row">
+                        <h2>
                             @printSSA(ssa)
-                            @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
+                        </h2>
+            <div class="ssa-amis">
+                        @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
+                            <div class="ssa-amis__item">
                                 @formatAmi(ami)
-                            }
+                            </div>
+                        }
+        </div>
+        <div class="row">
+            <div class="ssa-amis">
+                    } else {
+                        <div class="ssa-amis__item">
+                            <div class="card">
+                                <div class="card-content">
+                                    @printSSA(ssa)
+                                    @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
+                                        @formatAmi(ami)
+                                    }
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            }
+                    }
+                }
+            </div>
         </div>
         @ssaAmiForm(stack, stage, app)
     </div>

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -5,9 +5,9 @@
 @main("Instance AMIs") {
     @heading("AMIs in use")
     <div class="container">
-        <div class="row">
+        <div class="ssa-amis">
             @for((ssa, amis) <- amiSSAs) {
-                <div class="col m4">
+                <div class="ssa-amis__item">
                     <div class="card">
                         <div class="card-content">
                             @printSSA(ssa)

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -37,21 +37,37 @@ dl.ami-details dt {
 }
 
 .ami-badge {
+    display: flex;
     position: relative;
+    margin: 10px 0;
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
 }
 
-.ami-badge .ami-icon {
-    position: absolute;
-    top: -13px;
-    left: -14px;
-    width: 40px;
-    border-radius: 4px;
+.ami-badge__description {
+    flex: 1;
+    padding: 10px 5px 10px 5px;
 }
 
-.ami-badge .ami-status {
-    width: 40px;
+.ami-badge__age {
+    flex: 0 0 55px;
+    align-self: stretch;
+    padding: 10px 4px 10px 2px;
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+}
+
+.ami-badge__icon-container {
+    flex: 0 0 35px;
+    align-self: center;
+    margin-left: 2px;
+}
+
+.ami-badge__icon {
+    width: 35px;
     vertical-align: middle;
 }
+
 
 table.tags td {
     padding: 0px;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -36,6 +36,44 @@ dl.ami-details dt {
     font-weight: bold;
 }
 
+.ssa-amis {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+}
+
+.ssa-amis__item {
+    width: 100%;
+}
+
+@media only screen and (min-width: 601px) {
+    .ssa-amis {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: space-between;
+    }
+
+    .ssa-amis:after {
+        content: "";
+        flex: 0 0 49%;
+    }
+
+    .ssa-amis__item {
+        flex: 0 0 49%;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    .ssa-amis__item {
+        flex: 0 0 32%;
+    }
+
+    .ssa-amis:after {
+        content: "";
+        flex: 0 0 32%;
+    }
+}
+
 .ami-badge {
     display: flex;
     position: relative;
@@ -50,9 +88,9 @@ dl.ami-details dt {
 }
 
 .ami-badge__age {
-    flex: 0 0 55px;
+    flex: 0 0 58px;
     align-self: stretch;
-    padding: 10px 4px 10px 2px;
+    padding: 10px 2px 10px 2px;
     border-top-right-radius: 20px;
     border-bottom-right-radius: 20px;
 }

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -183,6 +183,27 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
   }
 
+  "sortSSAAmisByAge" - {
+    val ssa1 = SSA(Some("stack-1"))
+    val ssa2 = SSA(Some("stack-2"))
+    val ssaEmpty = SSA()
+    val oldAmi = emptyAmi("old").copy(creationDate = Some(DateTime.now.minusDays(40)))
+    val newAmi = emptyAmi("new").copy(creationDate = Some(DateTime.now.minusDays(1)))
+    val mediumAmi = emptyAmi("medium").copy(creationDate = Some(DateTime.now.minusDays(20)))
+
+    "puts an SSA group with an old AMI before one with a newer AMI" in {
+      sortSSAAmisByAge(Map(ssa1 -> List(oldAmi), ssa2 -> List(newAmi))).map(_._1) should contain inOrderOnly(ssa1, ssa2)
+    }
+
+    "sorts by oldest AMI (SSA with old AMI goes first, even if it has a new AMI as well)" in {
+      sortSSAAmisByAge(Map(ssa1 -> List(oldAmi, newAmi), ssa2 -> List(mediumAmi))).map(_._1) should contain inOrderOnly(ssa1, ssa2)
+    }
+
+    "empty SSA goes last even if it has the oldest AMIs" in {
+      sortSSAAmisByAge(Map(ssaEmpty -> List(oldAmi), ssa1 -> List(newAmi))).map(_._1) should contain inOrderOnly(ssa1, ssaEmpty)
+    }
+  }
+
   "amiIsOld" - {
     "returns false for a fresh AMI" in {
       val a1 = emptyAmi("a1").copy(creationDate = Some(DateTime.now.minusDays(1)))

--- a/test/prism/UrlsTest.scala
+++ b/test/prism/UrlsTest.scala
@@ -1,5 +1,6 @@
 package prism
 
+import models.SSA
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import prism.Urls._
@@ -21,43 +22,31 @@ class UrlsTest extends FreeSpec with Matchers with EitherValues with AttemptValu
     val root = "http://root"
 
     "should contain the stack as a GET variable" in {
-      instancesUrl(Some("stack"), None, None, root) should include("stack=stack")
+      instancesUrl(SSA(Some("stack"), None, None), root) should include("stack=stack")
     }
 
     "should contain the stage as a GET variable" in {
-      instancesUrl(None, Some("stage"), None, root) should include("stage=stage")
+      instancesUrl(SSA(None, Some("stage"), None), root) should include("stage=stage")
     }
 
     "should contain the app as a GET variable" in {
-      instancesUrl(None, None, Some("app"), root) should include("app=app")
+      instancesUrl(SSA(None, None, Some("app")), root) should include("app=app")
     }
 
     "should not contain an app parameter if no app is provided" in {
-      instancesUrl(Some("stack"), Some("stage"), None, root) shouldNot include("app=app")
+      instancesUrl(SSA(Some("stack"), Some("stage"), None), root) shouldNot include("app=app")
     }
 
     "should not contain a stage parameter if no stage is provided" in {
-      instancesUrl(Some("stack"), None, Some("app"), root) shouldNot include("stage=stage")
+      instancesUrl(SSA(Some("stack"), None, Some("app")), root) shouldNot include("stage=stage")
     }
 
     "should not contain a stack parameter if no stack is provided" in {
-      instancesUrl(None, Some("stage"), Some("app"), root) shouldNot include("stack=stack")
+      instancesUrl(SSA(None, Some("stage"), Some("app")), root) shouldNot include("stack=stack")
     }
 
     "uses the instances path" in {
-      instancesUrl(None, None, None, root) should startWith(s"$root/instances?")
-    }
-
-    "ignores empty stage" in {
-      instancesUrl(Some(""), None, None, root) shouldNot include(s"stage=")
-    }
-
-    "ignores empty stack" in {
-      instancesUrl(Some(""), None, None, root) shouldNot include(s"stack=")
-    }
-
-    "ignores empty app" in {
-      instancesUrl(Some(""), None, None, root) shouldNot include(s"app=")
+      instancesUrl(SSA(None, None, None), root) should startWith(s"$root/instances?")
     }
   }
 

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -1,8 +1,16 @@
 package util
 
-import play.api.libs.json.{JsObject, JsValue}
+import models.{AMI, Instance, Meta, Origin}
+import org.joda.time.DateTime
 
 object Fixtures {
+  def emptyAmi: AMI =
+    AMI("", None, "", "", None, Map.empty, None, "", "", "", "", "",  None)
+  def emptyInstance(arn: String): Instance =
+    Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
+  def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
+    amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
+
   object AMIs {
     val validAMI = """{
                      |  "arn": "arn:aws:ec2:region::image/ami-example",

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -1,15 +1,17 @@
 package util
 
-import models.{AMI, Instance, Meta, Origin}
+import models._
 import org.joda.time.DateTime
 
 object Fixtures {
-  def emptyAmi: AMI =
-    AMI("", None, "", "", None, Map.empty, None, "", "", "", "", "",  None)
+  def emptyAmi(arn: String): AMI =
+    AMI(arn, None, "", "", None, Map.empty, None, "", "", "", "", "",  None)
   def emptyInstance(arn: String): Instance =
     Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
   def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
     amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
+  def instanceWithSSA(arn: String, ssa: SSA): Instance =
+    emptyInstance(arn).copy(stack = ssa.stack, stage = ssa.stage, app = ssa.app.toList)
 
   object AMIs {
     val validAMI = """{


### PR DESCRIPTION
Displays instance AMIs by stack/app/stage to show their usage.

Note: This change drops support for showing AMIs that could not be looked up. If that's required it'll need to be added in another PR. One change at a time!

![ssa-amis](https://cloud.githubusercontent.com/assets/29761/13425409/7bcef622-df9e-11e5-8918-c34442ac138b.png)
