### PR TITLE
Improve SSA display on instance AMIs page

### DIFF
--- a/app/controllers/AMIable.scala
+++ b/app/controllers/AMIable.scala
@@ -62,7 +62,7 @@ class AMIable extends Controller {
         amisWithInstances = PrismLogic.amiInstances(amis, instances)
         amiSSAs = PrismLogic.amiSSAs(amisWithInstances)
       } yield {
-        Ok(views.html.instanceAMIs(ssa.stack, ssa.stage, ssa.app, PrismLogic.sortSSAAmisByAge(amiSSAs)))
+        Ok(views.html.instanceAMIs(ssa.stack, ssa.stage, ssa.app, amis, PrismLogic.sortSSAAmisByAge(amiSSAs)))
       }
     }
   }

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,15 +1,18 @@
-@(ssa: SSA)
+@(ssa: SSA, emptyChar: String = "-")
 
-@if(ssa.isEmpty) {
-    No stack/stage/app
-} else {
-    @ssa.stack.map { stack =>
-        <span class="chip">@stack</span>
-    }
-    @ssa.stage.map { stage =>
-        <span class="chip">@stage</span>
-    }
-    @ssa.app.map { app =>
-        <span class="chip">@app</span>
-    }
-}
+<table class="ssa-table">
+    <thead>
+        <tr>
+            <th class="ssa-table__heading">Stack</th>
+            <th class="ssa-table__heading">Stage</th>
+            <th class="ssa-table__heading">App</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
+        </tr>
+    </tbody>
+</table>

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -1,11 +1,34 @@
-@(stack: Option[String], stage: Option[String], app: Option[String], amiSSAs: List[(SSA, scala.List[AMI])])
+@(stack: Option[String], stage: Option[String], app: Option[String], amis: List[AMI], amiSSAs: List[(SSA, scala.List[AMI])])
 
 @import views.html.fragments.{ssaAmiForm, formatAmi, heading, printSSA}
 
 @main("Instance AMIs") {
-    @heading("AMIs in use")
+    <div class="heading grey lighten-3">
+        <div class="container">
+            <div class="row">
+                <div class="col m7">
+                    <h1>AMIs in use</h1>
+                </div>
+                <div class="col m5 hide-on-small-only">
+                    <p class="right-align"><a href="#search">[edit search]</a></p>
+                    @printSSA(SSA(stack, stage, app), "*")
+                </div>
+            </div>
+
+        </div>
+    </div>
     <div class="container">
         <div class="row">
+            <div class="amis-list">
+                @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
+                    <div class="amis-list__item">
+                        @formatAmi(ami)
+                    </div>
+                }
+            </div>
+        </div>
+        <div class="row">
+            <h2>AMI usage</h2>
             <div class="ssa-amis">
                 @for((ssa, amis) <- amiSSAs) {
                     @if(ssa.isEmpty) {
@@ -14,9 +37,7 @@
         </div>
 
         <div class="row">
-                        <h2>
-                            @printSSA(ssa)
-                        </h2>
+            @printSSA(ssa)
             <div class="ssa-amis">
                         @for(ami <- amis.sortBy(_.creationDate.map(_.getMillis))) {
                             <div class="ssa-amis__item">
@@ -41,6 +62,7 @@
                 }
             </div>
         </div>
+        <a name="search"></a>
         @ssaAmiForm(stack, stage, app)
     </div>
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -22,6 +22,10 @@ h1 {
     margin-bottom: 1em;
 }
 
+.heading-right {
+    padding-top: 30px;
+}
+
 .old-instance-count {
     margin: 20px 0 5px 0;
     font-size:10rem;
@@ -44,6 +48,14 @@ dl.ami-details dt {
 
 .ssa-amis__item {
     width: 100%;
+}
+
+.ssa-table__heading {
+    padding-top: 0;
+}
+
+.ssa-table__entry {
+    padding-bottom: 0;
 }
 
 @media only screen and (min-width: 601px) {
@@ -70,6 +82,38 @@ dl.ami-details dt {
 
     .ssa-amis:after {
         content: "";
+        flex: 0 0 32%;
+    }
+}
+
+.amis-list__item {
+    width: 100%;
+}
+
+@media only screen and (min-width: 601px) {
+    .amis-list {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: space-between;
+    }
+
+    .amis-list:after {
+        content: "";
+        flex: 0 0 49%;
+    }
+
+    .amis-list__item {
+        flex: 0 0 49%;
+    }
+}
+
+@media only screen and (min-width: 720px) {
+    .amis-list:after {
+        content: "";
+        flex: 0 0 32%;
+    }
+
+    .amis-list__item {
         flex: 0 0 32%;
     }
 }


### PR DESCRIPTION
Lists all found AMIs first, then shows usage. Consistently displays the SSA in a table for clarity.

![instancessa-display](https://cloud.githubusercontent.com/assets/29761/13460237/449198bc-e071-11e5-9874-d8a8f2e9ce60.png)
