### PR TITLE
Add agent to provide old instance count to cloudwatch

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,4 +1,5 @@
 import com.google.inject.AbstractModule
+import services.{Agents, CloudWatch}
 
 
 /**
@@ -13,6 +14,7 @@ import com.google.inject.AbstractModule
   */
 class Module extends AbstractModule {
   override def configure() = {
-
+    bind(classOf[Agents]).asEagerSingleton()
+    bind(classOf[CloudWatch]).asEagerSingleton()
   }
 }

--- a/app/aws/AwsAsyncHandler.scala
+++ b/app/aws/AwsAsyncHandler.scala
@@ -1,0 +1,26 @@
+package aws
+
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.handlers.AsyncHandler
+import play.api.Logger
+
+import scala.concurrent.{Future, Promise}
+
+
+class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T]) extends AsyncHandler[R, T] {
+  def onError(e: Exception) = {
+    Logger.warn("Failed to execute AWS SDK operation", e)
+    promise failure e
+  }
+  def onSuccess(r: R, t: T) = {
+    promise success t
+  }
+}
+
+object AwsAsyncHandler {
+  def awsToScala[R <: AmazonWebServiceRequest, T](sdkMethod: Function2[R, AsyncHandler[R, T], java.util.concurrent.Future[T]]): Function1[R, Future[T]] = { req =>
+    val p = Promise[T]
+    sdkMethod(req, new AwsAsyncPromiseHandler(p))
+    p.future
+  }
+}

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -11,28 +11,33 @@ import play.api.{Environment, Logger, Mode}
 import prism.{Prism, PrismLogic}
 import rx.lang.scala.Observable
 
-import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 
 @Singleton
 class Agents @Inject()(amiableConfigProvider: AmiableConfigProvider, lifecycle: ApplicationLifecycle, system: ActorSystem, environment: Environment)(implicit exec: ExecutionContext) {
   lazy implicit val conf = amiableConfigProvider.conf
+  val refreshInterval = 5.minutes
 
   private val amisAgent: Agent[Set[AMI]] = Agent(Set.empty)
   private val ssasAgent: Agent[Set[SSA]] = Agent(Set.empty)
+  private val oldProdInstanceCountAgent: Agent[Option[Int]] = Agent(None)
 
   def allAmis: Set[AMI] = amisAgent.get
   def allSSAs: Set[SSA] = ssasAgent.get
+  def oldProdInstanceCount: Option[Int] = oldProdInstanceCountAgent.get
 
   if (environment.mode != Mode.Test) {
     refreshAmis()
     refreshSSAs()
+    refreshOldProdInstanceCount()
 
-    val subscription = Observable.interval(5.minutes).subscribe { _ =>
+    val subscription = Observable.interval(refreshInterval).subscribe { _ =>
       Logger.debug(s"Refreshing agents")
       refreshAmis()
       refreshSSAs()
+      refreshOldProdInstanceCount()
     }
 
     lifecycle.addStopHook { () =>
@@ -41,7 +46,7 @@ class Agents @Inject()(amiableConfigProvider: AmiableConfigProvider, lifecycle: 
     }
   }
 
-  def refreshAmis() = {
+  def refreshAmis(): Unit = {
     Prism.getAMIs().fold(
       { err =>
         Logger.warn(s"Failed to update AMIs ${err.logString}")
@@ -53,7 +58,7 @@ class Agents @Inject()(amiableConfigProvider: AmiableConfigProvider, lifecycle: 
     )
   }
 
-  def refreshSSAs() = {
+  def refreshSSAs(): Unit = {
     Prism.getInstances(SSA()).map(PrismLogic.instanceSSAs).fold(
       { err =>
         Logger.warn(s"Failed to update SSAs ${err.logString}")
@@ -61,6 +66,19 @@ class Agents @Inject()(amiableConfigProvider: AmiableConfigProvider, lifecycle: 
       { ssas =>
         Logger.debug(s"Loaded ${ssas.size} SSA combinations")
         ssasAgent.send(ssas.toSet)
+      }
+    )
+  }
+
+  def refreshOldProdInstanceCount(): Unit = {
+    Prism.instancesWithAmis(SSA(stage = Some("PROD"))).fold(
+      { err =>
+        Logger.warn(s"Failed to update old PROD instance count ${err.logString}")
+      },
+      { prodInstances =>
+        val oldInstances = PrismLogic.oldInstances(prodInstances)
+        Logger.debug(s"Found ${oldInstances.size} PROD instances running on an out-of-date AMI")
+        oldProdInstanceCountAgent.send(Some(oldInstances.size))
       }
     )
   }

--- a/app/services/CloudWatch.scala
+++ b/app/services/CloudWatch.scala
@@ -1,0 +1,65 @@
+package services
+
+import javax.inject.{Inject, Singleton}
+
+import aws.AwsAsyncHandler.awsToScala
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+import play.api.inject.ApplicationLifecycle
+import play.api.{Environment, Logger, Mode}
+import rx.lang.scala.Observable
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+
+@Singleton
+class CloudWatch @Inject()(environment: Environment, agents: Agents, lifecycle: ApplicationLifecycle) {
+  // only add metrics from PROD
+  if (environment.mode == Mode.Prod) {
+    val credentialsProvider = new AWSCredentialsProviderChain(
+      new InstanceProfileCredentialsProvider()
+      // add profile to chain if required for local dev
+      // new ProfileCredentialsProvider("profile-name")
+    )
+    val cloudwatchClient: AmazonCloudWatchAsyncClient = new AmazonCloudWatchAsyncClient(credentialsProvider).withRegion(Regions.EU_WEST_1)
+
+    val subscription = Observable.interval(initialDelay = 10.seconds, period = agents.refreshInterval).subscribe { _ =>
+      Logger.info(s"Updating cloudwatch, ${agents.oldProdInstanceCount}")
+      agents.oldProdInstanceCount.fold {
+        Logger.warn("Not updating cloudwatch - no old PROD instance count available")
+      }{ count =>
+        val metricDataRequest = CloudWatch.putOldCountRequest(count)
+        awsToScala(cloudwatchClient.putMetricDataAsync)(metricDataRequest)
+        Logger.debug(s"Updated CloudWatch with out-of-date instances count: $count")
+      }
+    }
+
+    lifecycle.addStopHook { () =>
+      subscription.unsubscribe()
+      Future.successful(())
+    }
+  }
+}
+object CloudWatch {
+  def putOldCountRequest(count: Int): PutMetricDataRequest = {
+    new PutMetricDataRequest()
+      .withNamespace("AMIs")
+      .withMetricData {
+        new MetricDatum()
+          .withMetricName("instances-running-out-of-date-amis")
+          .withValue(count.toDouble)
+          .withDimensions (
+            new Dimension()
+              .withName("stage")
+              .withValue("PROD"),
+            new Dimension()
+              .withName("stack")
+              .withValue("*")
+          )
+      }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   ws,
   "com.typesafe.akka" %% "akka-agent" % "2.4.2",
   "io.reactivex" %% "rxscala" % "0.26.0",
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.67",
   specs2 % Test,
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
   "org.mockito" % "mockito-core" % "1.10.19" % Test

--- a/test/services/CloudWatchTest.scala
+++ b/test/services/CloudWatchTest.scala
@@ -1,0 +1,29 @@
+package services
+
+import org.scalatest.{OptionValues, Matchers, FreeSpec}
+import collection.JavaConverters._
+
+
+class CloudWatchTest extends FreeSpec with Matchers with OptionValues {
+  "putOldCountRequest" - {
+    "sets provided count value" in {
+      val metricDataRequest = CloudWatch.putOldCountRequest(5)
+      val metricDatum = metricDataRequest.getMetricData.asScala.headOption.value
+      metricDatum.getValue shouldEqual 5
+    }
+
+    "sets stack dimension with '*'" in {
+      val metricDataRequest = CloudWatch.putOldCountRequest(5)
+      val dimensions = metricDataRequest.getMetricData.asScala.headOption.value.getDimensions.asScala
+      val stageDimension = dimensions.find(_.getName == "stack").value
+      stageDimension.getValue shouldEqual "*"
+    }
+
+    "sets stage dimension with 'PROD'" in {
+      val metricDataRequest = CloudWatch.putOldCountRequest(5)
+      val dimensions = metricDataRequest.getMetricData.asScala.headOption.value.getDimensions.asScala
+      val stageDimension = dimensions.find(_.getName == "stage").value
+      stageDimension.getValue shouldEqual "PROD"
+    }
+  }
+}


### PR DESCRIPTION
Sends "the number of PROD instances running out of date AMIs" to cloudwatch as a metric. This is something that can be used to track the effectiveness of AMIable.