### PR TITLE
Trigger modal by clicking anywhere on AMI badge

### DIFF
--- a/public/javascripts/amiable.js
+++ b/public/javascripts/amiable.js
@@ -1,3 +1,12 @@
 jQuery(function($) {
     $('.modal-trigger').leanModal();
+
+    $(".ami-badge").each(function(i, el){
+        var badge = $(el);
+        badge.css("cursor", "pointer");
+        badge.click(function(){
+            var modalId = badge.find(".modal-trigger").attr("href");
+            $(modalId).openModal();
+        });
+    });
 });


### PR DESCRIPTION
Makes the entire AMI badge clickable. Especially important now that the styling no longer contains a "link".