### PR TITLE
Show instance total count next to out-of-date count

### DIFF
--- a/app/controllers/AMIable.scala
+++ b/app/controllers/AMIable.scala
@@ -23,7 +23,7 @@ class AMIable @Inject()(override val amiableConfigProvider: AmiableConfigProvide
         prodInstances <- Prism.instancesWithAmis(SSA(stage = Some("PROD")))
         oldInstances = PrismLogic.oldInstances(prodInstances)
         oldStacks = PrismLogic.stacks(oldInstances)
-      } yield Ok(views.html.index(oldInstances, oldStacks.sorted, agents.oldProdInstanceCountHistory))
+      } yield Ok(views.html.index(prodInstances.length, oldInstances, oldStacks.sorted, agents.oldProdInstanceCountHistory))
     }
   }
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,9 @@
-@(oldInstances: List[Instance], oldStacks: List[String], oldCountData: List[(org.joda.time.DateTime, Double)])
+@(
+        totalInstances: Int,
+        oldInstances: List[Instance],
+        oldStacks: List[String],
+        oldCountData: List[(org.joda.time.DateTime, Double)]
+)
 
 @import views.html.fragments.ssaAmiForm
 
@@ -11,8 +16,8 @@
                     <p class="grey-text darken-1">
                         Instances running on an out-of-date AMI
                     </p>
-                    <div class="old-instance-count deep-purple-text">
-                        @oldInstances.size
+                    <div class="deep-purple-text">
+                        <span class="old-instance-count">@oldInstances.size</span> <span class="total-instance-count">/ @totalInstances</span>
                     </div>
                     @if(oldCountData.nonEmpty) {
                         <div class="old-instance-count-chart__container">

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -31,8 +31,12 @@ h1 {
 }
 
 .old-instance-count {
-    margin-top: -25px;
+    line-height: 1em;
     font-size:8rem;
+}
+
+.total-instance-count {
+    font-size:1.5rem;
 }
 
 .old-instance-count-chart__container {


### PR DESCRIPTION
Out-of-date instances info is more meaningful when compared to the total number of instances

Before:
<img width="467" alt="screen shot 2017-02-02 at 10 31 40" src="https://cloud.githubusercontent.com/assets/233326/22545955/d509c8c2-e932-11e6-8e8e-6c59177e4eeb.png">

After:
<img width="466" alt="screen shot 2017-02-02 at 10 31 28" src="https://cloud.githubusercontent.com/assets/233326/22545962/dab19f20-e932-11e6-88b7-fde65db4852c.png">

