### PR TITLE
Fix percentiles label layout bug on medium sized screen

### DIFF
--- a/app/views/fragments/metricsHeader.scala.html
+++ b/app/views/fragments/metricsHeader.scala.html
@@ -8,7 +8,7 @@
     </div>
     <div>
         <div class="percentiles">
-            <div class="percentiles-col"><span>Days:</span></div>
+            <div class="percentiles-col"><span>Age in days:</span></div>
             <div class="percentiles-col"><span>@metrics.agePercentiles.p25</span></div>
             <div class="percentiles-col"><span>@metrics.agePercentiles.p50</span></div>
             <div class="percentiles-col"><span>@metrics.agePercentiles.p75</span></div>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -332,10 +332,15 @@ h1 {
     padding: 6px 0;
 }
 
+.percentiles-col:nth-child(1) {
+    min-width: 8em;
+}
+
 .percentiles-col:nth-child(1) span {
     color: #9e9e9e;
     text-align: left;
     left: 0;
+    padding-left: 0.3em;
 }
 
 .percentiles-col:before,
@@ -348,16 +353,11 @@ h1 {
 }
 
 .percentiles-col:nth-child(1):before {
-    content: 'AMIs age percentiles:';
+    content: 'Percentiles:';
     font-size: 14px;
     color: #9e9e9e;
     left: 0;
-}
-
-@media only screen and (max-width: 992px) { /* small and medium screens */
-    .percentiles-col:nth-child(1):before {
-        content: 'AMIs age pctl:';
-    }
+    padding-left: 0.3em;
 }
 
 .percentiles-col:nth-child(2):before {


### PR DESCRIPTION
Also add some left padding so labels doesn't seat on the edge and change label string to make them slightly the same length. :D

Before:
![screen shot 2017-02-24 at 12 33 00](https://cloud.githubusercontent.com/assets/233326/23303756/d8bc3b50-fa8d-11e6-95ef-ef9ca9bb288f.png)

After:
![screen shot 2017-02-24 at 12 34 30](https://cloud.githubusercontent.com/assets/233326/23303758/dd1ad5e4-fa8d-11e6-84c5-cafb5c113f88.png)
