### PR TITLE
Add basic documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ For this reason, in order to set up locally, the following steps must be followe
  In order to setup the auth parameters (eg. `serviceAccountCertPath`),
  please consult someone from the Dev Tools team.
  
+ - Finally open your browser at `https://amiable.local.dev-gutools.co.uk`!
+ 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
 Amiable
 =======
+Amiable is a web app for monitoring the use of AMIs.
+You can access it here:
+https://amiable.gutools.co.uk
 
-Managing your AMIs.
+
+### How to run Amiable locally
+
+Amiable uses Google Auth.
+For this reason, in order to set up locally, the following steps must be followed:
+ - Enter the following entry in your `/etc/hosts` file:
+```
+# Amiable
+127.0.0.1   amiable.local.dev-gutools.co.uk
+```
+ 
+ - Set up nginx.
+ In case you don't have nginx you must first install it.
+ To do that in Mac run: `brew install nginx` (requires [homebrew](https://brew.sh/))
+
+ To set up nginx simply run the script `./nginx/amiable.sh`
+ 
+ - Setup Amiable configuration.
+ A conf file is expected from Amiable.
+ The location of that file (as shown in `./sbt`) is: `$HOME/.gu/amiable.local.conf`
+ That file must contain all the configuration values that exist in `application.conf`
+ 
+ For example the following values must be set:
+ ```
+    APPLICATION_SECRET="abcdefghijklmnopqrstuvwxyz"
+    PRISM_URL="http://prism.gutools.co.uk"
+    HOST="https://amiable.local.dev-gutools.co.uk"
+ ```
+ In order to setup the auth parameters (eg. `serviceAccountCertPath`),
+ please consult someone from the Dev Tools team.
+ 

--- a/nginx/amiable.sh
+++ b/nginx/amiable.sh
@@ -5,7 +5,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 
-sudo ln -fs $DIR/amiable.conf $nginxHome/sites-enabled/amiable.conf
+if [ "$(uname)" == "Darwin" ]; then
+    # Mac OS X platform
+    confDir=servers
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    #  GNU/Linux platform
+    confDir=sites-enabled
+fi
+
+sudo ln -fs $DIR/amiable.conf $nginxHome/$confDir/amiable.conf
 sudo ln -fs $DIR/amiable.crt $nginxHome/amiable.crt
 sudo ln -fs $DIR/amiable.key $nginxHome/amiable.key
 sudo nginx -s stop

--- a/nginx/amiable.sh
+++ b/nginx/amiable.sh
@@ -5,11 +5,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 
-if [ "$(uname)" == "Darwin" ]; then
+SYSTEM=$(uname -s)
+if [ $SYSTEM == "Darwin" ]; then
     # Mac OS X platform
     confDir=servers
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    #  GNU/Linux platform
+elif [ $SYSTEM == "Linux" ]; then
     confDir=sites-enabled
 fi
 


### PR DESCRIPTION
Add some documentation on how to run Amiable locally.
There is no description on how to set up the Google Auth configuration (the steps through the Google console) and people are prompted to contact a Dev Tool person (there is no relevant email yet!)

Apart from that, the `nginx` when installed using`homebrew` is expecting the conf file in a different location (there is an entry `include servers/*;` in the last line of `nginx.conf`).
Because of that amended also the `amiable.sh`. 