### PR TITLE
A few minor changes to iterate on the amiable e-mail

### DIFF
--- a/app/services/notification/NotificationJob.scala
+++ b/app/services/notification/NotificationJob.scala
@@ -1,11 +1,11 @@
 package services.notification
 
-import config.AMIableConfig
-import org.quartz.{Job, JobExecutionContext, SchedulerContext}
-import play.api.{Configuration, Logger}
+import org.joda.time.DateTime
+import org.quartz.{Job, JobExecutionContext}
+import play.api.Logger
 
-import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
 
 /** Quartz job wrapper for [[ScheduledNotificationRunner]] */
 class NotificationJob extends Job {
@@ -14,7 +14,7 @@ class NotificationJob extends Job {
     val schedulerContext = context.getScheduler.getContext
     val scheduledNotificationRunner = schedulerContext.get("ScheduledNotificationRunner").asInstanceOf[ScheduledNotificationRunner]
     implicit val ec = schedulerContext.get("ExecutionContext").asInstanceOf[ExecutionContext]
-    val result = scheduledNotificationRunner.run()
+    val result = scheduledNotificationRunner.run(new DateTime())
     Await.result(result.asFuture, 10.minutes).fold(
       err => Logger.error(s"Failed to send scheduled notifications: ${err.logString}"), { msgs =>
         Logger.info(s"Email notifications: ${msgs.size} sent")

--- a/app/services/notification/Notifications.scala
+++ b/app/services/notification/Notifications.scala
@@ -4,13 +4,14 @@ import javax.inject.{Inject, Singleton}
 
 import config.{AMIableConfig, AmiableConfigProvider}
 import models.Attempt
+import org.joda.time.DateTime
+import org.quartz.{JobKey, TriggerKey}
 import org.quartz.CronScheduleBuilder.cronSchedule
 import org.quartz.JobBuilder.newJob
-import org.quartz.{JobKey, TriggerKey}
 import org.quartz.TriggerBuilder.newTrigger
 import org.quartz.impl.StdSchedulerFactory
+import play.api.{Environment, Logger}
 import play.api.inject.ApplicationLifecycle
-import play.api.{Configuration, Environment, Logger, Mode}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -61,6 +62,6 @@ class Notifications @Inject()(amiableConfigProvider: AmiableConfigProvider,
   }
 
   def sendEmail(): Attempt[List[String]] = {
-    scheduledNotificationRunner.run()
+    scheduledNotificationRunner.run(new DateTime())
   }
 }

--- a/app/views/email.scala.html
+++ b/app/views/email.scala.html
@@ -1,7 +1,8 @@
 @import utils.DateUtils
 @import views.html.fragments.heading
 
-@(instances: Seq[Instance], owner: Owner, emptyChar: String = "-")
+@import org.joda.time.DateTime
+@(amiableUrl: String, instances: Seq[(Instance, Option[AMI])], owner: Owner, emptyChar: String = "-")
 
 <!DOCTYPE html>
 <html lang="en">
@@ -16,34 +17,49 @@
                 <thead>
                     <tr bgcolor="#aabbd9">
                         <td colspan="7" bgcolor="#eeeeee" style="font-size: xx-large; color: #3661B0 !important; padding: 40px 40px 30px 40px;">
-                            @{instances.size} instances are running using old (>30 days) AMIs
+                            <div>@{instances.size} instances running old AMIs</div>
+                            <div><small>(AMIs built more than 30 days ago)</small></div>
                         </td>
                     </tr>
                     <tr bgcolor="#26a69a">
                         <th align="left" style="padding: 15px 5px;">Stack</th>
                         <th align="left" style="padding: 15px 5px;">Stage</th>
                         <th align="left" style="padding: 15px 5px;">App</th>
-                        <th align="left" style="padding: 15px 5px;">State</th>
-                        <th align="left" style="padding: 15px 5px;">Instance name</th>
-                        <th align="left" style="padding: 15px 5px;">IP</th>
-                        <th align="left" style="padding: 15px 5px;">Creation date</th>
+                        <th align="left" style="padding: 15px 5px;">Instance</th>
+                        <th align="left" style="padding: 15px 5px;">AMI</th>
+                        <th align="left" style="padding: 15px 5px;">AMI age</th>
                     </tr>
                 </thead>
                 <tbody>
-                @for(instance <- instances) {
-                    <tr>
-                        <td style="padding: 15px 5px;">@instance.stack.getOrElse(emptyChar)</td>
-                        <td style="padding: 15px 5px;">@instance.stage.getOrElse(emptyChar)</td>
-                        <td style="padding: 15px 5px;">@instance.app</td>
-                        <td style="padding: 15px 5px;">@instance.vendorState</td>
-                        <td style="padding: 15px 5px;">@instance.instanceName</td>
-                        <td style="padding: 15px 5px;">@instance.ip</td>
-                        <td style="padding: 15px 5px;">@DateUtils.readableDateTime.print(instance.createdAt)</td>
-                    </tr>
+                @for((instance, maybeAmi) <- instances) {
+                        <tr>
+                            <td style="padding: 5px 5px;">
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, None, None).path}">
+                                    @instance.stack.getOrElse(emptyChar)
+                                </a>
+                            </td>
+                            <td style="padding: 5px 5px;">
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, None).path}">@instance.stage.getOrElse(emptyChar)</a>
+                            </td>
+                            <td style="padding: 5px 5px;">
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, instance.app.headOption).path}">@instance.app</a>
+                            </td>
+                            <td style="padding: 5px 5px;">@instance.instanceName</td>
+                            <td style="padding: 5px 5px;">
+                                @maybeAmi.map { ami =>
+                                    <a href="@{amiableUrl + routes.AMIable.ami(ami.imageId).path}">@ami.imageId</a>
+                                }
+                            </td>
+                            <td style="padding: 5px 5px;">@maybeAmi.flatMap(_.creationDate).map { i => @DateUtils.daysAgo(i)
+                                days
+                            }</td>
+                        </tr>
                 }
                 <tr bgcolor="#212121" style="color: #FFFFFF !important; padding: 30px 30px 30px 30px;">
                     <td colspan="7" style="padding: 15px 5px;">
-                        You are receiving this email because you are listed as the Owner of the following stacks:
+                        You are receiving this email because you are listed as the Owner of the stacks listed below.
+                        This is determined by the Owners in prism (see
+                            <a href="https://github.com/guardian/prism/blob/master/app/data/Owners.scala">GitHub</a>).
                         <table cellpadding="5px">
                             <thead>
                                 <tr>

--- a/nginx/amiable.sh
+++ b/nginx/amiable.sh
@@ -5,7 +5,13 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 
-confDir=sites-enabled
+SYSTEM=$(uname -s)
+if [ $SYSTEM == "Darwin" ]; then
+    # Mac OS X platform
+    confDir=servers
+elif [ $SYSTEM == "Linux" ]; then
+    confDir=sites-enabled
+fi
 
 sudo ln -fs $DIR/amiable.conf $nginxHome/$confDir/amiable.conf
 sudo ln -fs $DIR/amiable.crt $nginxHome/amiable.crt

--- a/nginx/amiable.sh
+++ b/nginx/amiable.sh
@@ -5,13 +5,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 
-SYSTEM=$(uname -s)
-if [ $SYSTEM == "Darwin" ]; then
-    # Mac OS X platform
-    confDir=servers
-elif [ $SYSTEM == "Linux" ]; then
-    confDir=sites-enabled
-fi
+confDir=sites-enabled
 
 sudo ln -fs $DIR/amiable.conf $nginxHome/$confDir/amiable.conf
 sudo ln -fs $DIR/amiable.crt $nginxHome/amiable.crt


### PR DESCRIPTION
A few changes:
 - make gmail / inbox treat the e-mails more sensibly rather than bundling them together (by putting the date and owner in subject)
 - change the columns of information in the e-mail to make it more relevant / useful
 - add a note on how the owners are derived
 - add links to the SSA and AMI columns

![screen shot 2017-06-20 at 18 54 32](https://user-images.githubusercontent.com/1236466/27347856-fb9ab2b6-55e9-11e7-9605-7afe4570bedc.png)
