### PR TITLE
add a link to riffraff next to SSA

### DIFF
--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -6,6 +6,7 @@
             <th class="ssa-table__heading">Stack</th>
             <th class="ssa-table__heading">Stage</th>
             <th class="ssa-table__heading">App</th>
+            <th class="ssa-table__heading"></th>
         </tr>
     </thead>
     <tbody>
@@ -13,6 +14,9 @@
             <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
             <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
             <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">
+                <a href="@{SSA.riffRaffLink(ssa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
+            </td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
There are two main reasons why amiable will flag an app as running an old instance:
- AMIgo hasn't built an image recently
- RiffRaff hasn't deployed the app recently

Having a link to RiffRaff in the SSA table makes it easier to determine which of the two is the reason, leading to a faster resolution.

# Before
![image](https://user-images.githubusercontent.com/836140/81173388-e307e300-8f97-11ea-906b-cefe67dc8233.png)

![image](https://user-images.githubusercontent.com/836140/81173409-ea2ef100-8f97-11ea-8f6b-494b5d177ab3.png)

# After
![image](https://user-images.githubusercontent.com/836140/81173344-cec3e600-8f97-11ea-831f-c5ec7eee152c.png)

![image](https://user-images.githubusercontent.com/836140/81173367-da171180-8f97-11ea-8050-e16bb041ad64.png)
