### PR TITLE
Replace hard coded date serialiser with play version.

### DIFF
--- a/app/models/Serialisation.scala
+++ b/app/models/Serialisation.scala
@@ -4,6 +4,8 @@ import play.api.libs.json.Json
 
 object Serialisation {
   import utils.DateUtils._
+  import play.api.libs.json.JodaWrites._
+  import play.api.libs.json.JodaReads._
 
   implicit val originFormat = Json.format[Origin]
   implicit val metaFormat = Json.format[Meta]

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -3,6 +3,8 @@ package models
 import org.joda.time.DateTime
 import play.api.libs.json._
 import utils.{DateUtils, Percentiles}
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
 
 case class AMI(
   arn: String,

--- a/app/utils/DateUtils.scala
+++ b/app/utils/DateUtils.scala
@@ -28,10 +28,6 @@ object DateUtils {
     }
   }
 
-  implicit val isoDateReads: Reads[DateTime] = JodaReads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  implicit val isoDateWrites: Writes[DateTime] = JodaWrites.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  implicit val jodaDateTimeFormats: Format[DateTime] = Format[DateTime](isoDateReads, isoDateWrites)
-
   val yearMonthDay: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
   val yearMonthDayTime: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm")
   val readableDateTime: DateTimeFormatter = DateTimeFormat.forPattern("dd MMMM yyyy 'at' HH:mm")

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -67,7 +67,7 @@ object Fixtures {
                           |      "ip": "0.0.0.0"
                           |    }
                           |  },
-                          |  "createdAt": "2016-02-09T10:59:01.000Z",
+                          |  "createdAt": "2020-11-13T18:56:59Z",
                           |  "instanceName": "i-id",
                           |  "region": "region",
                           |  "vendor": "aws",

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -67,7 +67,7 @@ object Fixtures {
                           |      "ip": "0.0.0.0"
                           |    }
                           |  },
-                          |  "createdAt": "2020-11-13T18:56:59Z",
+                          |  "createdAt": "2016-02-09T10:59:01.000Z",
                           |  "instanceName": "i-id",
                           |  "region": "region",
                           |  "vendor": "aws",


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/prism/pull/99/files#diff-99e8aff9e82352e9e7be6d0002a173dd26ee897fb56621045a0286cc3e99a742R51 the formats of dates in Prism has changed. This PR solves a problem with amiable where it was failing to parse the new date format coming from prism for the `createdAt` datetime on the `Instance` object.

The solution replaces manual date formatters with ones comng from the play library, which seems a sensible improvement (thanks @sihil )

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run amiable, check that the UI doesn't throw a big error like this one:

<img width="392" alt="Screenshot 2020-12-01 at 14 46 33" src="https://user-images.githubusercontent.com/3606555/100755397-0b4ba900-33e4-11eb-8392-83ee07014ca7.png">

