### PR TITLE
Add filtering by account name.

### DIFF
--- a/app/controllers/AMIable.scala
+++ b/app/controllers/AMIable.scala
@@ -28,12 +28,12 @@ class AMIable (val controllerComponents: ControllerComponents, val amiableConfig
     attempt {
       for {
         instancesWithAmis <- Prism.instancesWithAmis(ssaa)
-        accountNames = PrismLogic.instanceSSAAs(instancesWithAmis.map(_._1)).flatMap(_.accountName).distinct
+        accountNames <- Prism.getAccounts
         oldInstances = PrismLogic.oldInstances(instancesWithAmis)
         oldStacks = PrismLogic.stacks(oldInstances)
         agePercentiles = PrismLogic.instancesAmisAgePercentiles(instancesWithAmis)
         metrics = Metrics(oldInstances.length, instancesWithAmis.length, agePercentiles)
-      } yield Ok(views.html.index(oldStacks.sorted, charts, metrics, accountNames))
+      } yield Ok(views.html.index(oldStacks.sorted, charts, metrics, accountNames.map(_.accountName)))
     }
   }
 

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -97,7 +97,11 @@ case class SSAA (
 
   def stackAccountLabel: String = if (stackAccountMatch) "Account/Stack" else "Stack"
 
-  override def toString: String = s"SSA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}, ${accountName.getOrElse("unknown-account")}>"
+  override def toString: String = {
+    // accountName is non optional in some cases so is often set to "". In these cases treat it as 'none'
+    val accountString = if (accountName.isEmpty || accountName.contains(""))"unknown-account" else accountName.get
+    s"SSA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}, ${accountString}>"
+  }
 }
 object SSAA {
   implicit val jsonFormat = Json.format[SSAA]

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -63,7 +63,7 @@ case class Instance(
 
 case class Origin(
   vendor: String,
-  accountName: String,
+  accountName: Option[String],
   region: String,
   accountNumber: String)
 

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -87,34 +87,14 @@ case class SSAA (
   accountName: Option[String] = None
 ) {
   def isEmpty = stack.isEmpty && stage.isEmpty && app.isEmpty
-  def stackAccountMatch: Boolean = {
-    val stackAccountCompare = for {
-      an <- accountName
-      s <- stack
-    } yield {an == s}
-    stackAccountCompare.contains(true)
-  }
-
-  def stackAccountLabel: String = if (stackAccountMatch) "Account/Stack" else "Stack"
-
   override def toString: String = {
     // accountName is non optional in some cases so is often set to "". In these cases treat it as 'none'
     val accountString = if (accountName.isEmpty || accountName.contains(""))"unknown-account" else accountName.get
-    s"SSA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}, ${accountString}>"
+    s"SSAA<${stack.getOrElse("none")}, ${stage.getOrElse("none")}, ${app.getOrElse("none")}, ${accountString}>"
   }
 }
 object SSAA {
   implicit val jsonFormat = Json.format[SSAA]
-
-  def stackAccountMatch(ssaa: SSAA): Boolean = {
-    val comparison = for {
-      accountName <- ssaa.accountName
-      stack <- ssaa.stack
-    } yield {
-      accountName == stack
-    }
-    comparison.contains(true)
-  }
 
   /**
     * Filters empty strings to None, such as those provided by request parameters.
@@ -124,10 +104,10 @@ object SSAA {
 
   def empty = SSAA(None, None, None, None)
 
-  def riffRaffLink(ssa: SSAA, region: String): Option[String] = for {
-    stack <- ssa.stack
-    stage <- ssa.stage
-    app <- ssa.app
+  def riffRaffLink(ssaa: SSAA, region: String): Option[String] = for {
+    stack <- ssaa.stack
+    stage <- ssaa.stage
+    app <- ssaa.app
   } yield {
     s"https://riffraff.gutools.co.uk/deployment/target/deploy?region=$region&stack=$stack&stage=$stage&app=$app"
   }
@@ -169,7 +149,7 @@ object LaunchConfiguration {
 }
 
 case class Owner(id: String, stacks: List[SSAA]) {
-  def hasSSA(ssa: SSAA): Boolean = stacks.contains(ssa)
+  def hasSSA(ssaa: SSAA): Boolean = stacks.contains(ssaa)
 }
 
 object Owner {

--- a/app/prism/JsonUtils.scala
+++ b/app/prism/JsonUtils.scala
@@ -71,6 +71,12 @@ object JsonUtils {
     }
   }
 
+  def accountsResponseJson(response: WSResponse): Attempt[List[JsValue]] = {
+    JsonUtils.jsResultToAttempt("Could not get aws accounts from response JSON") {
+      (response.json \ "data" ).validate[List[JsValue]]
+    }
+  }
+
   def ownersResponseJson(response: WSResponse)(implicit ec: ExecutionContext): Attempt[JsValue] = {
     JsonUtils.extractToAttempt("Could not get Owners from response JSON") {
       (response.json \ "data").validate[JsValue]
@@ -86,6 +92,12 @@ object JsonUtils {
   def extractLaunchConfiguration(json: JsValue): Attempt[LaunchConfiguration] = {
     JsonUtils.extractToAttempt[LaunchConfiguration]("Could not get Launch Configuration from response JSON") {
       json.validate[LaunchConfiguration]
+    }
+  }
+
+  def extractAccounts(json: JsValue): Attempt[AWSAccount] = {
+    JsonUtils.extractToAttempt[AWSAccount]("Could not get Accounts from response JSON") {
+      json.validate[AWSAccount]
     }
   }
 

--- a/app/prism/Prism.scala
+++ b/app/prism/Prism.scala
@@ -38,7 +38,7 @@ object Prism {
     } yield amis
   }
 
-  def getInstances(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[Instance]] = {
+  def getInstances(stackStageApp: SSAA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[Instance]] = {
     val url = instancesUrl(stackStageApp, config.prismUrl)
     getInstancesFromUrl(url)
   }
@@ -56,7 +56,7 @@ object Prism {
     } yield instances
   }
 
-  def instancesWithAmis(stackStageApp: SSA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[(Instance, Option[AMI])]] = {
+  def instancesWithAmis(stackStageApp: SSAA)(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[(Instance, Option[AMI])]] = {
     for {
       prodInstances <- getInstances(stackStageApp)
       amiAttempts = amiArns(prodInstances).map(getAMI)
@@ -71,5 +71,14 @@ object Prism {
       jsons <- launchConfigurationResponseJson(response)
       launchConfigurations <- Attempt.sequence(jsons.map(extractLaunchConfiguration))
     } yield launchConfigurations
+  }
+
+  def getAccounts(implicit config: AMIableConfig, ec: ExecutionContext): Attempt[List[AWSAccount]] = {
+    val url = s"${config.prismUrl}/sources/accounts"
+    for {
+      response <- Http.response(config.wsClient.url(url).get(), "Unable to fetch accounts list", url)
+      jsons <- accountsResponseJson(response)
+      accounts <- Attempt.sequence(jsons.map(extractAccounts))
+    } yield accounts
   }
 }

--- a/app/prism/PrismLogic.scala
+++ b/app/prism/PrismLogic.scala
@@ -47,8 +47,8 @@ object PrismLogic {
     val allInstanceSSAs = for {
       instance <- instances
       ssaa <- {
-        if (instance.app.isEmpty) List(SSAA(instance.stack, instance.stage, None, Some(instance.meta.origin.accountName)))
-        else instance.app.map(app => SSAA(instance.stack, instance.stage, Some(app), Some(instance.meta.origin.accountName)))
+        if (instance.app.isEmpty) List(SSAA(instance.stack, instance.stage, None, instance.meta.origin.accountName))
+        else instance.app.map(app => SSAA(instance.stack, instance.stage, Some(app), instance.meta.origin.accountName))
       }
     } yield ssaa
     allInstanceSSAs.distinct
@@ -130,7 +130,7 @@ object PrismLogic {
     * and by Launch Configuration name, in ascending order
     */
   def sortLCsByOwner(configs: List[LaunchConfiguration]): List[LaunchConfiguration] = {
-    configs.sortBy(lc => (lc.meta.origin.accountName, lc.name))
+    configs.sortBy(lc => (lc.meta.origin.accountName.getOrElse(""), lc.name))
   }
 
   /**

--- a/app/prism/PrismLogic.scala
+++ b/app/prism/PrismLogic.scala
@@ -46,39 +46,39 @@ object PrismLogic {
   def instanceSSAAs(instances: List[Instance]): List[SSAA] = {
     val allInstanceSSAs = for {
       instance <- instances
-      ssa <- {
+      ssaa <- {
         if (instance.app.isEmpty) List(SSAA(instance.stack, instance.stage, None, Some(instance.meta.origin.accountName)))
         else instance.app.map(app => SSAA(instance.stack, instance.stage, Some(app), Some(instance.meta.origin.accountName)))
       }
-    } yield ssa
+    } yield ssaa
     allInstanceSSAs.distinct
   }
 
   /**
     * T will either be an AMI, or an AMI attempt.
     * From a full list of Ts and instances, return each unique
-    * SSA combination with all its associated Ts.
+    * SSAA combination with all its associated Ts.
     */
-  def amiSSAs[T](amisWithInstances: List[(T, List[Instance])]): Map[SSAA, List[T]] = {
+  def amiSSAAs[T](amisWithInstances: List[(T, List[Instance])]): Map[SSAA, List[T]] = {
     val allSSACombos = for {
       (t, instances) <- amisWithInstances
-      ssa <- instanceSSAAs(instances)
-    } yield ssa -> t
+      ssaa <- instanceSSAAs(instances)
+    } yield ssaa -> t
 
     allSSACombos
-      .groupBy { case (ssa, _) => ssa }
-      .map { case (ssa, ssaAmis) =>
-        ssa -> ssaAmis.map { case (_, t) => t }
+      .groupBy { case (ssaa, _) => ssaa }
+      .map { case (ssaa, ssaaAmis) =>
+        ssaa -> ssaaAmis.map { case (_, t) => t }
       }
   }
 
   /**
-    * SSAs are sorted by their oldest AMI, except for the empty SSA which
+    * SSAAs are sorted by their oldest AMI, except for the empty SSAA which
     * always appears last.
     */
-  def sortSSAAmisByAge(ssaAmis: Map[SSAA, List[AMI]]): List[(SSAA, List[AMI])] = {
-    ssaAmis.toList.sortBy { case (ssa, amis) =>
-      if (ssa.isEmpty) {
+  def sortSSAAmisByAge(ssaaAmis: Map[SSAA, List[AMI]]): List[(SSAA, List[AMI])] = {
+    ssaaAmis.toList.sortBy { case (ssaa, amis) =>
+      if (ssaa.isEmpty) {
         // put empty SSA last
         DateTime.now.getMillis
       } else {
@@ -110,20 +110,20 @@ object PrismLogic {
   /**
     * T will either be an AMI, or an AMI attempt.
     * From a full list of Ts and instances and a list of SSAs, return unique
-    * SSA and AMI combinations with their respective number of instances
+    * SSAA and AMI combinations with their respective number of instances
     */
   def instancesCountPerSsaPerAmi[T](amisWithInstances: List[(T, List[Instance])], ssas: List[SSAA]): Map[(SSAA, T), Int] = {
     for {
       (t, instances) <- amisWithInstances.toMap
-      ssa <- ssas
-      instancesCount = instances.count(i => doesInstanceBelongToSSA(i, ssa))
+      ssaa <- ssas
+      instancesCount = instances.count(i => doesInstanceBelongToSSA(i, ssaa))
       if(instancesCount > 0)
-    } yield (ssa, t) -> instancesCount
+    } yield (ssaa, t) -> instancesCount
   }
 
-  def doesInstanceBelongToSSA(instance: Instance, ssa: SSAA): Boolean = ssa.stack == instance.stack &&
-    ssa.stage.fold(true)(s => instance.stage.contains(s)) &&
-    ssa.app.fold(true)(instance.app.contains(_))
+  def doesInstanceBelongToSSA(instance: Instance, ssaa: SSAA): Boolean = ssaa.stack == instance.stack &&
+    ssaa.stage.fold(true)(s => instance.stage.contains(s)) &&
+    ssaa.app.fold(true)(instance.app.contains(_))
 
   /**
     * Sort Launch Configurations by accountName (ie. the owner of the stack)

--- a/app/prism/Urls.scala
+++ b/app/prism/Urls.scala
@@ -21,9 +21,9 @@ object Urls {
 
   private[prism] def emptyToNone(strOpt: Option[String]) = strOpt.filter(_.nonEmpty)
 
-  def instancesUrl(ssa: SSAA, prismUrl: String) = {
+  def instancesUrl(ssaa: SSAA, prismUrl: String) = {
     val getVars = for {
-      (name, strOpt) <- List("stack" -> ssa.stack, "stage" -> ssa.stage, "app" -> ssa.app, "meta.origin.accountName" -> ssa.accountName)
+      (name, strOpt) <- List("stack" -> ssaa.stack, "stage" -> ssaa.stage, "app" -> ssaa.app, "meta.origin.accountName" -> ssaa.accountName)
       getVar <- strOpt.map(str =>  s"$name=${URLEncoder.encode(str, "UTF-8")}")
     } yield getVar
     s"$prismUrl/instances?${getVars.mkString("&")}"

--- a/app/prism/Urls.scala
+++ b/app/prism/Urls.scala
@@ -2,7 +2,7 @@ package prism
 
 import java.net.URLEncoder
 
-import models.SSA
+import models.SSAA
 
 
 object Urls {
@@ -21,9 +21,9 @@ object Urls {
 
   private[prism] def emptyToNone(strOpt: Option[String]) = strOpt.filter(_.nonEmpty)
 
-  def instancesUrl(ssa: SSA, prismUrl: String) = {
+  def instancesUrl(ssa: SSAA, prismUrl: String) = {
     val getVars = for {
-      (name, strOpt) <- List("stack" -> ssa.stack, "stage" -> ssa.stage, "app" -> ssa.app)
+      (name, strOpt) <- List("stack" -> ssa.stack, "stage" -> ssa.stage, "app" -> ssa.app, "meta.origin.accountName" -> ssa.accountName)
       getVar <- strOpt.map(str =>  s"$name=${URLEncoder.encode(str, "UTF-8")}")
     } yield getVar
     s"$prismUrl/instances?${getVars.mkString("&")}"

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -23,7 +23,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   val refreshInterval = 5.minutes
 
   private val amisAgent: Agent[Set[AMI]] = Agent(Set.empty)
-  private val ssasAgent: Agent[Set[SSA]] = Agent(Set.empty)
+  private val ssasAgent: Agent[Set[SSAA]] = Agent(Set.empty)
   private val oldProdInstanceCountAgent: Agent[Option[Int]] = Agent(None)
   private val oldProdInstanceCountHistoryAgent: Agent[List[(DateTime, Double)]] = Agent(Nil)
   private val amisAgePercentilesAgent: Agent[Option[Percentiles]] = Agent(None)
@@ -32,7 +32,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   private val amisAgePercentile75thHistoryAgent: Agent[List[(DateTime, Double)]] = Agent(Nil)
 
   def allAmis: Set[AMI] = amisAgent.get
-  def allSSAs: Set[SSA] = ssasAgent.get
+  def allSSAs: Set[SSAA] = ssasAgent.get
   def oldProdInstanceCount: Option[Int] = oldProdInstanceCountAgent.get
   def oldProdInstanceCountHistory: List[(DateTime, Double)] = oldProdInstanceCountHistoryAgent.get
   def amisAgePercentiles: Option[Percentiles] = amisAgePercentilesAgent.get
@@ -77,7 +77,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   }
 
   def refreshSSAs(): Unit = {
-    Prism.getInstances(SSA()).map(PrismLogic.instanceSSAs).fold(
+    Prism.getInstances(SSAA()).map(PrismLogic.instanceSSAAs).fold(
       { err =>
         Logger.warn(s"Failed to update SSAs ${err.logString}")
       },
@@ -89,7 +89,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   }
 
   def refreshInstancesInfo(): Unit = {
-    Prism.instancesWithAmis(SSA(stage = Some("PROD"))).fold(
+    Prism.instancesWithAmis(SSAA(stage = Some("PROD"))).fold(
       { err =>
         Logger.warn(s"Failed to update old PROD instance count ${err.logString}")
       },

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -81,9 +81,9 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
       { err =>
         Logger.warn(s"Failed to update SSAs ${err.logString}")
       },
-      { ssas =>
-        Logger.debug(s"Loaded ${ssas.size} SSA combinations")
-        ssasAgent.send(ssas.toSet)
+      { ssaas =>
+        Logger.debug(s"Loaded ${ssaas.size} SSAA combinations")
+        ssasAgent.send(ssaas.toSet)
       }
     )
   }

--- a/app/services/notification/ScheduledNotificationRunner.scala
+++ b/app/services/notification/ScheduledNotificationRunner.scala
@@ -16,7 +16,7 @@ class ScheduledNotificationRunner @Inject() (mailClient: AWSMailClient, environm
 
   def run(today: DateTime): Attempt[List[String]] = {
     for {
-      instancesWithAmis <- Prism.instancesWithAmis(SSA(stage = Some("PROD")))
+      instancesWithAmis <- Prism.instancesWithAmis(SSAA(stage = Some("PROD")))
       oldInstances = PrismLogic.oldInstances(instancesWithAmis)
       instanceAmiMap = ScheduledNotificationRunner.makeInstanceAmiMap(instancesWithAmis)
       ownersWithDefault <- Prism.getOwners
@@ -32,10 +32,10 @@ class ScheduledNotificationRunner @Inject() (mailClient: AWSMailClient, environm
 
 object ScheduledNotificationRunner {
   def ownerForInstance(i: Instance, owners: Owners): Owner = {
-    owners.owners.find(_.hasSSA(SSA(i.stack, i.stage, i.app.headOption)))
-      .orElse(owners.owners.find(_.hasSSA(SSA(i.stack, app = i.app.headOption))))
-      .orElse(owners.owners.find(_.hasSSA(SSA(i.stack, i.stage))))
-      .orElse(owners.owners.find(_.hasSSA(SSA(i.stack))))
+    owners.owners.find(_.hasSSA(SSAA(i.stack, i.stage, i.app.headOption)))
+      .orElse(owners.owners.find(_.hasSSA(SSAA(i.stack, app = i.app.headOption))))
+      .orElse(owners.owners.find(_.hasSSA(SSAA(i.stack, i.stage))))
+      .orElse(owners.owners.find(_.hasSSA(SSAA(i.stack))))
       .getOrElse(owners.defaultOwner)
   }
 

--- a/app/views/email.scala.html
+++ b/app/views/email.scala.html
@@ -66,6 +66,7 @@
                                     <th class="ssa-table__heading">Stack</th>
                                     <th class="ssa-table__heading">Stage</th>
                                     <th class="ssa-table__heading">App</th>
+                                    <th class="ssa-table__heading">Account</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -74,6 +75,7 @@
                                     <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
                                     <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
                                     <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
+                                    <td class="ssa-table__entry">@ssa.accountName.getOrElse(emptyChar)</td>
                                 </tr>
                             }
                             </tbody>

--- a/app/views/email.scala.html
+++ b/app/views/email.scala.html
@@ -34,15 +34,15 @@
                 @for((instance, maybeAmi) <- instances) {
                         <tr>
                             <td style="padding: 5px 5px;">
-                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, None, None).path}">
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, None, None, None).path}">
                                     @instance.stack.getOrElse(emptyChar)
                                 </a>
                             </td>
                             <td style="padding: 5px 5px;">
-                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, None).path}">@instance.stage.getOrElse(emptyChar)</a>
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, None, None).path}">@instance.stage.getOrElse(emptyChar)</a>
                             </td>
                             <td style="padding: 5px 5px;">
-                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, instance.app.headOption).path}">@instance.app</a>
+                                <a href="@{amiableUrl+routes.AMIable.ssaInstanceAMIs(instance.stack, instance.stage, instance.app.headOption, None).path}">@instance.app</a>
                             </td>
                             <td style="padding: 5px 5px;">@instance.instanceName</td>
                             <td style="padding: 5px 5px;">

--- a/app/views/fragments/amiOverlay.scala.html
+++ b/app/views/fragments/amiOverlay.scala.html
@@ -68,8 +68,8 @@
         }
         <a href="#!" class="black-text modal-action modal-close waves-effect waves-white btn grey lighten-3">Close</a>
         @if(ami.upgrade.isDefined) {
-            @stackStageApp.map { ssa =>
-                @SSAA.riffRaffLink(ssa, ami.region).map { link =>
+            @stackStageApp.map { ssaa =>
+                @SSAA.riffRaffLink(ssaa, ami.region).map { link =>
                     <a href="@link" target="_blank" rel="noopener" class="waves-effect waves-light btn">Redeploy</a>
                 }
             }

--- a/app/views/fragments/amiOverlay.scala.html
+++ b/app/views/fragments/amiOverlay.scala.html
@@ -1,4 +1,4 @@
-@(ami: AMI, instanceCount: Option[Int] = None, id: String = java.util.UUID.randomUUID.toString, stackStageApp: Option[SSA] = None)
+@(ami: AMI, instanceCount: Option[Int] = None, id: String = java.util.UUID.randomUUID.toString, stackStageApp: Option[SSAA] = None)
 
 @import utils.DateUtils.{getAgeColour, daysAgo}
 @import views.html.fragments.amiWithUpgrade
@@ -69,7 +69,7 @@
         <a href="#!" class="black-text modal-action modal-close waves-effect waves-white btn grey lighten-3">Close</a>
         @if(ami.upgrade.isDefined) {
             @stackStageApp.map { ssa =>
-                @SSA.riffRaffLink(ssa, ami.region).map { link =>
+                @SSAA.riffRaffLink(ssa, ami.region).map { link =>
                     <a href="@link" target="_blank" rel="noopener" class="waves-effect waves-light btn">Redeploy</a>
                 }
             }

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,24 +1,28 @@
 @(ssa: SSAA, emptyChar: String = "-")
 
-<table class="ssa-table">
-    <thead>
-        <tr>
-            @if(!ssa.stackAccountMatch){ <th class="ssa-table__heading">Account</th> }
-            <th class="ssa-table__heading">@ssa.stackAccountLabel</th>
-            <th class="ssa-table__heading">Stage</th>
-            <th class="ssa-table__heading">App</th>
-            <th class="ssa-table__heading"></th>
-        </tr>
-    </thead>
+<table class="striped">
     <tbody>
         <tr>
-            @if(!ssa.stackAccountMatch){<td class="ssa-table__entry">@ssa.accountName.getOrElse(emptyChar)</td> }
-            <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
-            <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
+            <td class="ssa-table__heading">App</td>
             <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
+        </tr>
+        <tr>
+            <td class="ssa-table__heading">Stage</td>
+            <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
+        </tr>
+        <tr>
+            <td class="ssa-table__heading">Stack</td>
+            <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
+        </tr>
+        <tr>
+            <td class="ssa-table__heading">Account</td>
+            <td class="ssa-table__entry">@ssa.accountName.getOrElse(emptyChar)</td>
+        </tr>
+        <tr>
+            <td class="ssa-table__heading"></td>
             <td class="ssa-table__entry">
                 <a href="@{SSAA.riffRaffLink(ssa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
             </td>
-        </tr>
+         </tr>
     </tbody>
 </table>

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,27 +1,27 @@
-@(ssa: SSAA, emptyChar: String = "-")
+@(ssaa: SSAA, emptyChar: String = "-")
 
 <table class="striped">
     <tbody>
         <tr>
             <td class="ssa-table__heading">App</td>
-            <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssaa.app.getOrElse(emptyChar)</td>
         </tr>
         <tr>
             <td class="ssa-table__heading">Stage</td>
-            <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssaa.stage.getOrElse(emptyChar)</td>
         </tr>
         <tr>
             <td class="ssa-table__heading">Stack</td>
-            <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssaa.stack.getOrElse(emptyChar)</td>
         </tr>
         <tr>
             <td class="ssa-table__heading">Account</td>
-            <td class="ssa-table__entry">@ssa.accountName.getOrElse(emptyChar)</td>
+            <td class="ssa-table__entry">@ssaa.accountName.getOrElse(emptyChar)</td>
         </tr>
         <tr>
             <td class="ssa-table__heading"></td>
             <td class="ssa-table__entry">
-                <a href="@{SSAA.riffRaffLink(ssa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
+                <a href="@{SSAA.riffRaffLink(ssaa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
             </td>
          </tr>
     </tbody>

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,9 +1,10 @@
-@(ssa: SSA, emptyChar: String = "-")
+@(ssa: SSAA, emptyChar: String = "-")
 
 <table class="ssa-table">
     <thead>
         <tr>
-            <th class="ssa-table__heading">Stack</th>
+            @if(!ssa.stackAccountMatch){ <th class="ssa-table__heading">Account</th> }
+            <th class="ssa-table__heading">@ssa.stackAccountLabel</th>
             <th class="ssa-table__heading">Stage</th>
             <th class="ssa-table__heading">App</th>
             <th class="ssa-table__heading"></th>
@@ -11,11 +12,12 @@
     </thead>
     <tbody>
         <tr>
+            @if(!ssa.stackAccountMatch){<td class="ssa-table__entry">@ssa.accountName.getOrElse(emptyChar)</td> }
             <td class="ssa-table__entry">@ssa.stack.getOrElse(emptyChar)</td>
             <td class="ssa-table__entry">@ssa.stage.getOrElse(emptyChar)</td>
             <td class="ssa-table__entry">@ssa.app.getOrElse(emptyChar)</td>
             <td class="ssa-table__entry">
-                <a href="@{SSA.riffRaffLink(ssa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
+                <a href="@{SSAA.riffRaffLink(ssa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
             </td>
         </tr>
     </tbody>

--- a/app/views/fragments/printSSA.scala.html
+++ b/app/views/fragments/printSSA.scala.html
@@ -1,17 +1,17 @@
 @(ssaa: SSAA, emptyChar: String = "-")
 
-<table class="striped">
+<table class="striped ssa-table">
     <tbody>
         <tr>
-            <td class="ssa-table__heading">App</td>
+            <td class="ssa-table__entry ssa-table__heading">App</td>
             <td class="ssa-table__entry">@ssaa.app.getOrElse(emptyChar)</td>
         </tr>
         <tr>
-            <td class="ssa-table__heading">Stage</td>
+            <td class="ssa-table__entry ssa-table__heading">Stage</td>
             <td class="ssa-table__entry">@ssaa.stage.getOrElse(emptyChar)</td>
         </tr>
         <tr>
-            <td class="ssa-table__heading">Stack</td>
+            <td class="ssa-table__entry ssa-table__heading">Stack</td>
             <td class="ssa-table__entry">@ssaa.stack.getOrElse(emptyChar)</td>
         </tr>
         <tr>
@@ -19,7 +19,7 @@
             <td class="ssa-table__entry">@ssaa.accountName.getOrElse(emptyChar)</td>
         </tr>
         <tr>
-            <td class="ssa-table__heading"></td>
+            <td class="ssa-table__entry ssa-table__heading"></td>
             <td class="ssa-table__entry">
                 <a href="@{SSAA.riffRaffLink(ssaa, "eu-west-1")}" target="_blank" rel="noopener noreferrer">Recent Deploys</a>
             </td>

--- a/app/views/fragments/ssaAmiForm.scala.html
+++ b/app/views/fragments/ssaAmiForm.scala.html
@@ -1,10 +1,19 @@
-@(ssa: SSA)
+@(ssa: SSAA, accountNames: List[String])
 
 
 <div class="card">
     <div class="card-content">
         <span class="card-title">Lookup AMI usage</span>
         <form action="/instanceAMIs" method="get" class="row">
+            <div class="input-field col m6">
+                <select name="accountName" id="accountName" value="@ssa.accountName.getOrElse("")" >
+                    <option value="" disabled selected>Choose AWS account</option>
+                @for(accountName <- accountNames) {
+                    <option value="@accountName" >@accountName</option>
+                }
+                </select>
+                <label for="accountName">Filter AMIs by account name</label>
+            </div>
             <div class="input-field col m6">
                 <input type="text" name="stack" id="stack" placeholder="Stack" value="@ssa.stack.getOrElse("")" />
                 <label for="stack">Filter AMIs by stack</label>

--- a/app/views/fragments/ssaAmiForm.scala.html
+++ b/app/views/fragments/ssaAmiForm.scala.html
@@ -1,4 +1,4 @@
-@(ssa: SSAA, accountNames: List[String])
+@(ssaa: SSAA, accountNames: List[String])
 
 
 <div class="card">
@@ -6,7 +6,7 @@
         <span class="card-title">Lookup AMI usage</span>
         <form action="/instanceAMIs" method="get" class="row">
             <div class="input-field col m6">
-                <select name="accountName" id="accountName" value="@ssa.accountName.getOrElse("")" >
+                <select name="accountName" id="accountName" value="@ssaa.accountName.getOrElse("")" >
                     <option value="" disabled selected>Choose AWS account</option>
                 @for(accountName <- accountNames) {
                     <option value="@accountName" >@accountName</option>
@@ -15,15 +15,15 @@
                 <label for="accountName">Filter AMIs by account name</label>
             </div>
             <div class="input-field col m6">
-                <input type="text" name="stack" id="stack" placeholder="Stack" value="@ssa.stack.getOrElse("")" />
+                <input type="text" name="stack" id="stack" placeholder="Stack" value="@ssaa.stack.getOrElse("")" />
                 <label for="stack">Filter AMIs by stack</label>
             </div>
             <div class="input-field col m6">
-                <input type="text" name="stage" id="stage" placeholder="Stage" value="@ssa.stage.getOrElse("")" />
+                <input type="text" name="stage" id="stage" placeholder="Stage" value="@ssaa.stage.getOrElse("")" />
                 <label for="stage">Filter AMIs by stage</label>
             </div>
             <div class="input-field col m6">
-                <input type="text" name="app" id="app" placeholder="App" value="@ssa.app.getOrElse("")" />
+                <input type="text" name="app" id="app" placeholder="App" value="@ssaa.app.getOrElse("")" />
                 <label for="app">Filter AMIs by app</label>
             </div>
             <div class="col m6">

--- a/app/views/fragments/ssaAmiForm.scala.html
+++ b/app/views/fragments/ssaAmiForm.scala.html
@@ -6,10 +6,10 @@
         <span class="card-title">Lookup AMI usage</span>
         <form action="/instanceAMIs" method="get" class="row">
             <div class="input-field col m6">
-                <select name="accountName" id="accountName" value="@ssaa.accountName.getOrElse("")" >
+                <select name="accountName" id="accountName" value="@ssaa.accountName.getOrElse("")">
                     <option value="" disabled selected>Choose AWS account</option>
                 @for(accountName <- accountNames) {
-                    <option value="@accountName" >@accountName</option>
+                    <option value="@accountName">@accountName</option>
                 }
                 </select>
                 <label for="accountName">Filter AMIs by account name</label>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
         oldStacks: List[String],
         charts: List[models.Chart],
         metrics: models.Metrics,
-    accountNames: List[String]
+        accountNames: List[String]
 )
 
 @import views.html.fragments.ssaAmiForm

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,7 +1,8 @@
 @(
         oldStacks: List[String],
         charts: List[models.Chart],
-        metrics: models.Metrics
+        metrics: models.Metrics,
+    accountNames: List[String]
 )
 
 @import views.html.fragments.ssaAmiForm
@@ -31,7 +32,7 @@
     <div class="container">
         <div class="row">
             <div class="col s12">
-                @ssaAmiForm(SSA.empty)
+                @ssaAmiForm(SSAA.empty, accountNames)
             </div>
             <div class="col m6">
                 <form action="/ami" method="get" class="row">

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -1,9 +1,10 @@
 @(
-        filterSsa: SSA,
+        filterSsa: SSAA,
         metrics: models.Metrics,
         amisWithUpgrades: List[AMI],
-        amiSSAs: List[(SSA, List[AMI])],
-        instancesCount: Map[(SSA, AMI), Int]
+        amiSSAs: List[(SSAA, List[AMI])],
+        instancesCount: Map[(SSAA, AMI), Int],
+        accountNames: List[String]
 )
 
 @import views.html.fragments.{ssaAmiForm, amiOverlay, printSSA, metricsHeader}
@@ -68,6 +69,6 @@
             </div>
         </div>
         <a name="search"></a>
-        @ssaAmiForm(filterSsa)
+        @ssaAmiForm(filterSsa, accountNames)
     </div>
 }()

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -43,6 +43,7 @@
         </div>
 
         <div class="row">
+            <div class="card empty-ssaa-card">
             @printSSA(ssaa)
             <div class="ssa-amis">
                         @for(ami <- amis) {
@@ -50,6 +51,7 @@
                                 @amiOverlay(ami, instancesCount.get(ssaa, ami))
                             </div>
                         }
+            </div>
         </div>
         <div class="row">
             <div class="ssa-amis">

--- a/app/views/instanceAMIs.scala.html
+++ b/app/views/instanceAMIs.scala.html
@@ -36,18 +36,18 @@
         <div class="row">
             <h2>AMI usage</h2>
             <div class="ssa-amis">
-                @for((ssa, amis) <- amiSSAs) {
-                    @if(ssa.isEmpty) {
+                @for((ssaa, amis) <- amiSSAs) {
+                    @if(ssaa.isEmpty) {
                         @* show AMIs with empty SSAs in their own block (there are lots of them) *@
             </div>
         </div>
 
         <div class="row">
-            @printSSA(ssa)
+            @printSSA(ssaa)
             <div class="ssa-amis">
                         @for(ami <- amis) {
                             <div class="ssa-amis__item">
-                                @amiOverlay(ami, instancesCount.get(ssa, ami))
+                                @amiOverlay(ami, instancesCount.get(ssaa, ami))
                             </div>
                         }
         </div>
@@ -57,9 +57,9 @@
                         <div class="ssa-amis__item">
                             <div class="card">
                                 <div class="card-content">
-                                    @printSSA(ssa)
+                                    @printSSA(ssaa)
                                     @for(ami <- amis) {
-                                        @amiOverlay(ami = ami, instanceCount = instancesCount.get(ssa, ami), stackStageApp = Some(ssa))
+                                        @amiOverlay(ami = ami, instanceCount = instancesCount.get(ssaa, ami), stackStageApp = Some(ssaa))
                                     }
                                 </div>
                             </div>

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 # Home page
 GET     /                           controllers.AMIable.index
 GET     /ami                        controllers.AMIable.ami(imageId: String)
-GET     /instanceAMIs               controllers.AMIable.ssaInstanceAMIs(stack: Option[String], stage: Option[String], app: Option[String])
+GET     /instanceAMIs               controllers.AMIable.ssaInstanceAMIs(stack: Option[String], stage: Option[String], app: Option[String], accountName: Option[String])
 GET     /healthcheck                controllers.Healthcheck.healthcheck
 
 GET     /loginError                 controllers.Login.loginError

--- a/public/javascripts/amiable.js
+++ b/public/javascripts/amiable.js
@@ -1,3 +1,7 @@
+$(document).ready(function(){
+    $('select').material_select();
+});
+
 jQuery(function($) {
     $('.modal-trigger').leanModal();
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -61,13 +61,20 @@ h1 {
     width: 100%;
 }
 
+.ssa-table {
+    max-width: 400px;
+}
 .ssa-table__heading {
-    padding: 3px;
     font-weight: bold;
 }
 
 .ssa-table__entry {
     padding: 3px;
+    max-width: 400px;
+}
+
+.empty-ssaa-card {
+    padding: 5px;
 }
 
 @media only screen and (min-width: 601px) {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -67,6 +67,8 @@ h1 {
 
 .ssa-table__entry {
     padding-bottom: 0;
+    word-wrap: break-word;
+    max-width: 80px;
 }
 
 @media only screen and (min-width: 601px) {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -62,13 +62,12 @@ h1 {
 }
 
 .ssa-table__heading {
-    padding-top: 0;
+    padding: 3px;
+    font-weight: bold;
 }
 
 .ssa-table__entry {
-    padding-bottom: 0;
-    word-wrap: break-word;
-    max-width: 80px;
+    padding: 3px;
 }
 
 @media only screen and (min-width: 601px) {

--- a/test/prism/JsonUtilsTest.scala
+++ b/test/prism/JsonUtilsTest.scala
@@ -124,4 +124,18 @@ class JsonUtilsTest extends FreeSpec with Matchers with EitherValues with Attemp
       extractLaunchConfiguration(json).awaitEither.isLeft shouldBe true
     }
   }
+
+  "extractAccounts" - {
+    "should return an accounts list from correct json" in {
+      val json = Json.parse(Accounts.validAccount)
+      val accounts = extractAccounts(json).awaitEither.right.value
+      accounts.accountName shouldEqual("barnard-castle")
+    }
+
+    "should return a failure given invalid json" in {
+      val jsonStr = """{"testyinvalid":123}"""
+      val json = Json.parse(jsonStr)
+      extractAccounts(json).awaitEither.isLeft shouldBe true
+    }
+  }
 }

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -108,7 +108,7 @@ class PrismLogicTest extends FreeSpec with Matchers {
   }
 
   "instanceSSAs" - {
-    val emptySSA = SSA(None, None, None)
+    val emptySSA = SSAA(None, None, None)
 
     "returns empty list for no instances" in {
       instanceSSAAs(Nil) shouldEqual Nil
@@ -124,13 +124,13 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
 
     "returns the correct SSA for an instance" in {
-      val ssa = SSA(Some("stack"), Some("app"), Some("app"))
+      val ssa = SSAA(Some("stack"), Some("app"), Some("app"))
       instanceSSAAs(List(instanceWithSSA("i1", ssa))) shouldEqual List(ssa)
     }
 
     "returns the correct SSAs for multiple instances" in {
-      val ssa1 = SSA(Some("stack-1"), Some("stage-1"), Some("app-1"))
-      val ssa2 = SSA(Some("stack-2"), Some("stage-2"), Some("app-2"))
+      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"))
+      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"))
       instanceSSAAs(List(instanceWithSSA("i1", ssa1), instanceWithSSA("i2", ssa2))) shouldEqual List(ssa1, ssa2)
     }
   }
@@ -140,8 +140,8 @@ class PrismLogicTest extends FreeSpec with Matchers {
     val a2 = emptyAmi("a2")
 
     "associates" - {
-      val ssa1 = SSA(Some("stack-1"), Some("stage-1"), Some("app-1"))
-      val ssa2 = SSA(Some("stack-2"), Some("stage-2"), Some("app-2"))
+      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"))
+      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"))
       val i1 = instanceWithSSA("i1", ssa1)
       val i2 = instanceWithSSA("i2", ssa2)
 
@@ -159,7 +159,7 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
 
     "if an instance's app is empty, associates with the stack/stage combo" in {
-      val stackStage = SSA(Some("stack"), Some("stage"), None)
+      val stackStage = SSAA(Some("stack"), Some("stage"), None)
       val instance = instanceWithSSA("i", stackStage)
       amiSSAs(List(a1 -> List(instance))) shouldEqual Map(stackStage -> List(a1))
     }
@@ -167,8 +167,8 @@ class PrismLogicTest extends FreeSpec with Matchers {
     "correctly associates instances with multiple apps" in {
       val instance = emptyInstance("i").copy(app = List("app1", "app2"))
       amiSSAs(List(a1 -> List(instance))) shouldEqual Map(
-        SSA(None, None, Some("app1")) -> List(a1),
-        SSA(None, None, Some("app2")) -> List(a1)
+        SSAA(None, None, Some("app1")) -> List(a1),
+        SSAA(None, None, Some("app2")) -> List(a1)
       )
     }
 
@@ -177,17 +177,17 @@ class PrismLogicTest extends FreeSpec with Matchers {
       val i2 = emptyInstance("i2").copy(app = List("app1", "app2"))
       val i3 = emptyInstance("i3").copy(app = List("app2"))
       amiSSAs(List(a1 -> List(i1, i2), a2 -> List(i3))) shouldEqual Map(
-        SSA(None, None, Some("app1")) -> List(a1),
-        SSA(None, None, Some("another-app")) -> List(a1),
-        SSA(None, None, Some("app2")) -> List(a1, a2)
+        SSAA(None, None, Some("app1")) -> List(a1),
+        SSAA(None, None, Some("another-app")) -> List(a1),
+        SSAA(None, None, Some("app2")) -> List(a1, a2)
       )
     }
   }
 
   "sortSSAAmisByAge" - {
-    val ssa1 = SSA(Some("stack-1"))
-    val ssa2 = SSA(Some("stack-2"))
-    val ssaEmpty = SSA()
+    val ssa1 = SSAA(Some("stack-1"))
+    val ssa2 = SSAA(Some("stack-2"))
+    val ssaEmpty = SSAA()
     val oldAmi = emptyAmi("old").copy(creationDate = Some(DateTime.now.minusDays(40)))
     val newAmi = emptyAmi("new").copy(creationDate = Some(DateTime.now.minusDays(1)))
     val mediumAmi = emptyAmi("medium").copy(creationDate = Some(DateTime.now.minusDays(20)))
@@ -269,9 +269,9 @@ class PrismLogicTest extends FreeSpec with Matchers {
 
   "instancesCountPerSsaPerAmi" - {
     "correctly associates the instance count with each couple SSA/AMI" in {
-      val ssa1 = SSA(Some("stack-1"), Some("stage-1"), Some("app-1"))
-      val ssa2 = SSA(Some("stack-2"), Some("stage-2"))
-      val ssa3 = SSA(Some("stack-3"))
+      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"))
+      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"))
+      val ssa3 = SSAA(Some("stack-3"))
       val a1 = emptyAmi("a1")
       val a2 = emptyAmi("a2")
       val i1 = emptyInstance("i1").copy(stack = Some("stack-1"), stage = Some("stage-1"), app = List("app-1"))
@@ -300,33 +300,33 @@ class PrismLogicTest extends FreeSpec with Matchers {
     val i1 = emptyInstance("i1").copy(stack = Some("stack1"), stage = Some("stage1"), app = List("app1"))
     "should return true when instance and SSA have" - {
       "the same stack" in {
-        val stack = SSA(stack = i1.stack)
+        val stack = SSAA(stack = i1.stack)
         doesInstanceBelongToSSA(i1, stack) should be(true)
       }
       "the same stack and stage" in {
-        val stack = SSA(stack = i1.stack, stage = i1.stage)
+        val stack = SSAA(stack = i1.stack, stage = i1.stage)
         doesInstanceBelongToSSA(i1, stack) should be(true)
       }
       "the same stack, stage and app" in {
-        val stack = SSA(stack = i1.stack, stage = i1.stage, app = i1.app.headOption)
+        val stack = SSAA(stack = i1.stack, stage = i1.stage, app = i1.app.headOption)
         doesInstanceBelongToSSA(i1, stack) should be(true)
       }
     }
     "should return false when instance and SSA have" - {
       "different stack" in {
-        val stack = SSA(stack = Some("another stack"))
+        val stack = SSAA(stack = Some("another stack"))
         doesInstanceBelongToSSA(i1, stack) should be(false)
       }
       "the same stack but different stage" in {
-        val stack = SSA(stack = i1.stack, stage = Some("another stage"))
+        val stack = SSAA(stack = i1.stack, stage = Some("another stage"))
         doesInstanceBelongToSSA(i1, stack) should be(false)
       }
       "the same stack and stage but different app" in {
-        val stack = SSA(stack = i1.stack, stage = i1.stack, app = Some("another app"))
+        val stack = SSAA(stack = i1.stack, stage = i1.stack, app = Some("another app"))
         doesInstanceBelongToSSA(i1, stack) should be(false)
       }
       "the same stage but different stack" in {
-        val stack = SSA(stack = Some("another stack"), stage = i1.stage)
+        val stack = SSAA(stack = Some("another stack"), stage = i1.stage)
         doesInstanceBelongToSSA(i1, stack) should be(false)
       }
     }

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -111,27 +111,27 @@ class PrismLogicTest extends FreeSpec with Matchers {
     val emptySSA = SSA(None, None, None)
 
     "returns empty list for no instances" in {
-      instanceSSAs(Nil) shouldEqual Nil
+      instanceSSAAs(Nil) shouldEqual Nil
     }
 
     "returns the empty SSA when an instance has no SSA fields" in {
-      instanceSSAs(List(instanceWithSSA("i1", emptySSA))) shouldEqual List(emptySSA)
+      instanceSSAAs(List(instanceWithSSA("i1", emptySSA))) shouldEqual List(emptySSA)
     }
 
     "returns single empty SSA for a collection of instances with no SSA fields" in {
       val instances = List(instanceWithSSA("i1", emptySSA), instanceWithSSA("i2", emptySSA))
-      instanceSSAs(instances) shouldEqual List(emptySSA)
+      instanceSSAAs(instances) shouldEqual List(emptySSA)
     }
 
     "returns the correct SSA for an instance" in {
       val ssa = SSA(Some("stack"), Some("app"), Some("app"))
-      instanceSSAs(List(instanceWithSSA("i1", ssa))) shouldEqual List(ssa)
+      instanceSSAAs(List(instanceWithSSA("i1", ssa))) shouldEqual List(ssa)
     }
 
     "returns the correct SSAs for multiple instances" in {
       val ssa1 = SSA(Some("stack-1"), Some("stage-1"), Some("app-1"))
       val ssa2 = SSA(Some("stack-2"), Some("stage-2"), Some("app-2"))
-      instanceSSAs(List(instanceWithSSA("i1", ssa1), instanceWithSSA("i2", ssa2))) shouldEqual List(ssa1, ssa2)
+      instanceSSAAs(List(instanceWithSSA("i1", ssa1), instanceWithSSA("i2", ssa2))) shouldEqual List(ssa1, ssa2)
     }
   }
 

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -108,7 +108,7 @@ class PrismLogicTest extends FreeSpec with Matchers {
   }
 
   "instanceSSAs" - {
-    val emptySSA = SSAA(None, None, None)
+    val emptySSA = SSAA(None, None, None, Some(""))
 
     "returns empty list for no instances" in {
       instanceSSAAs(Nil) shouldEqual Nil
@@ -124,13 +124,13 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
 
     "returns the correct SSA for an instance" in {
-      val ssa = SSAA(Some("stack"), Some("app"), Some("app"))
+      val ssa = SSAA(Some("stack"), Some("app"), Some("app"), Some("account"))
       instanceSSAAs(List(instanceWithSSA("i1", ssa))) shouldEqual List(ssa)
     }
 
     "returns the correct SSAs for multiple instances" in {
-      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"))
-      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"))
+      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"), Some("acc-1"))
+      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"), Some("acc-2"))
       instanceSSAAs(List(instanceWithSSA("i1", ssa1), instanceWithSSA("i2", ssa2))) shouldEqual List(ssa1, ssa2)
     }
   }
@@ -140,8 +140,8 @@ class PrismLogicTest extends FreeSpec with Matchers {
     val a2 = emptyAmi("a2")
 
     "associates" - {
-      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"))
-      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"))
+      val ssa1 = SSAA(Some("stack-1"), Some("stage-1"), Some("app-1"), Some("acc-1"))
+      val ssa2 = SSAA(Some("stack-2"), Some("stage-2"), Some("app-2"), Some("acc-2"))
       val i1 = instanceWithSSA("i1", ssa1)
       val i2 = instanceWithSSA("i2", ssa2)
 
@@ -159,27 +159,27 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
 
     "if an instance's app is empty, associates with the stack/stage combo" in {
-      val stackStage = SSAA(Some("stack"), Some("stage"), None)
+      val stackStage = SSAA(Some("stack"), Some("stage"), None, Some("acc-1"))
       val instance = instanceWithSSA("i", stackStage)
       amiSSAs(List(a1 -> List(instance))) shouldEqual Map(stackStage -> List(a1))
     }
 
     "correctly associates instances with multiple apps" in {
-      val instance = emptyInstance("i").copy(app = List("app1", "app2"))
+      val instance = emptyInstance("i").copy(app = List("app1", "app2"), meta=Meta("", Origin("", "acc-1", "", "")))
       amiSSAs(List(a1 -> List(instance))) shouldEqual Map(
-        SSAA(None, None, Some("app1")) -> List(a1),
-        SSAA(None, None, Some("app2")) -> List(a1)
+        SSAA(None, None, Some("app1"), Some("acc-1")) -> List(a1),
+        SSAA(None, None, Some("app2"), Some("acc-1")) -> List(a1)
       )
     }
 
     "combines multi-app instances with other instances" in {
-      val i1 = emptyInstance("i1").copy(app = List("app1", "another-app"))
-      val i2 = emptyInstance("i2").copy(app = List("app1", "app2"))
-      val i3 = emptyInstance("i3").copy(app = List("app2"))
+      val i1 = emptyInstance("i1").copy(app = List("app1", "another-app"), meta=Meta("", Origin("", "acc-1", "", "")))
+      val i2 = emptyInstance("i2").copy(app = List("app1", "app2"), meta=Meta("", Origin("", "acc-1", "", "")))
+      val i3 = emptyInstance("i3").copy(app = List("app2"), meta=Meta("", Origin("", "acc-1", "", "")))
       amiSSAs(List(a1 -> List(i1, i2), a2 -> List(i3))) shouldEqual Map(
-        SSAA(None, None, Some("app1")) -> List(a1),
-        SSAA(None, None, Some("another-app")) -> List(a1),
-        SSAA(None, None, Some("app2")) -> List(a1, a2)
+        SSAA(None, None, Some("app1"), Some("acc-1")) -> List(a1),
+        SSAA(None, None, Some("another-app"), Some("acc-1")) -> List(a1),
+        SSAA(None, None, Some("app2"), Some("acc-1")) -> List(a1, a2)
       )
     }
   }

--- a/test/prism/PrismLogicTest.scala
+++ b/test/prism/PrismLogicTest.scala
@@ -124,8 +124,8 @@ class PrismLogicTest extends FreeSpec with Matchers {
     }
 
     "returns the correct SSA for an instance" in {
-      val ssa = SSAA(Some("stack"), Some("app"), Some("app"), Some("account"))
-      instanceSSAAs(List(instanceWithSSA("i1", ssa))) shouldEqual List(ssa)
+      val ssaa = SSAA(Some("stack"), Some("app"), Some("app"), Some("account"))
+      instanceSSAAs(List(instanceWithSSA("i1", ssaa))) shouldEqual List(ssaa)
     }
 
     "returns the correct SSAs for multiple instances" in {
@@ -146,27 +146,27 @@ class PrismLogicTest extends FreeSpec with Matchers {
       val i2 = instanceWithSSA("i2", ssa2)
 
       "an SSA with an AMI" in {
-        amiSSAs(List(a1 -> List(i1))) shouldEqual Map(ssa1 -> List(a1))
+        amiSSAAs(List(a1 -> List(i1))) shouldEqual Map(ssa1 -> List(a1))
       }
 
       "an SSA with multiple AMIs" in {
-        amiSSAs(List(a1 -> List(i1), a2 -> List(i1))) shouldEqual Map(ssa1 -> List(a1, a2))
+        amiSSAAs(List(a1 -> List(i1), a2 -> List(i1))) shouldEqual Map(ssa1 -> List(a1, a2))
       }
 
       "an AMI with multiple SSAs when it's used on different instances" in {
-        amiSSAs(List(a1 -> List(i1, i2))) shouldEqual Map(ssa1 -> List(a1), ssa2 -> List(a1))
+        amiSSAAs(List(a1 -> List(i1, i2))) shouldEqual Map(ssa1 -> List(a1), ssa2 -> List(a1))
       }
     }
 
     "if an instance's app is empty, associates with the stack/stage combo" in {
       val stackStage = SSAA(Some("stack"), Some("stage"), None, Some("acc-1"))
       val instance = instanceWithSSA("i", stackStage)
-      amiSSAs(List(a1 -> List(instance))) shouldEqual Map(stackStage -> List(a1))
+      amiSSAAs(List(a1 -> List(instance))) shouldEqual Map(stackStage -> List(a1))
     }
 
     "correctly associates instances with multiple apps" in {
       val instance = emptyInstance("i").copy(app = List("app1", "app2"), meta=Meta("", Origin("", "acc-1", "", "")))
-      amiSSAs(List(a1 -> List(instance))) shouldEqual Map(
+      amiSSAAs(List(a1 -> List(instance))) shouldEqual Map(
         SSAA(None, None, Some("app1"), Some("acc-1")) -> List(a1),
         SSAA(None, None, Some("app2"), Some("acc-1")) -> List(a1)
       )
@@ -176,7 +176,7 @@ class PrismLogicTest extends FreeSpec with Matchers {
       val i1 = emptyInstance("i1").copy(app = List("app1", "another-app"), meta=Meta("", Origin("", "acc-1", "", "")))
       val i2 = emptyInstance("i2").copy(app = List("app1", "app2"), meta=Meta("", Origin("", "acc-1", "", "")))
       val i3 = emptyInstance("i3").copy(app = List("app2"), meta=Meta("", Origin("", "acc-1", "", "")))
-      amiSSAs(List(a1 -> List(i1, i2), a2 -> List(i3))) shouldEqual Map(
+      amiSSAAs(List(a1 -> List(i1, i2), a2 -> List(i3))) shouldEqual Map(
         SSAA(None, None, Some("app1"), Some("acc-1")) -> List(a1),
         SSAA(None, None, Some("another-app"), Some("acc-1")) -> List(a1),
         SSAA(None, None, Some("app2"), Some("acc-1")) -> List(a1, a2)

--- a/test/prism/UrlsTest.scala
+++ b/test/prism/UrlsTest.scala
@@ -1,6 +1,6 @@
 package prism
 
-import models.SSA
+import models.SSAA
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import prism.Urls._

--- a/test/prism/UrlsTest.scala
+++ b/test/prism/UrlsTest.scala
@@ -22,31 +22,31 @@ class UrlsTest extends FreeSpec with Matchers with EitherValues with AttemptValu
     val root = "http://root"
 
     "should contain the stack as a GET variable" in {
-      instancesUrl(SSA(Some("stack"), None, None), root) should include("stack=stack")
+      instancesUrl(SSAA(Some("stack"), None, None), root) should include("stack=stack")
     }
 
     "should contain the stage as a GET variable" in {
-      instancesUrl(SSA(None, Some("stage"), None), root) should include("stage=stage")
+      instancesUrl(SSAA(None, Some("stage"), None), root) should include("stage=stage")
     }
 
     "should contain the app as a GET variable" in {
-      instancesUrl(SSA(None, None, Some("app")), root) should include("app=app")
+      instancesUrl(SSAA(None, None, Some("app")), root) should include("app=app")
     }
 
     "should not contain an app parameter if no app is provided" in {
-      instancesUrl(SSA(Some("stack"), Some("stage"), None), root) shouldNot include("app=app")
+      instancesUrl(SSAA(Some("stack"), Some("stage"), None), root) shouldNot include("app=app")
     }
 
     "should not contain a stage parameter if no stage is provided" in {
-      instancesUrl(SSA(Some("stack"), None, Some("app")), root) shouldNot include("stage=stage")
+      instancesUrl(SSAA(Some("stack"), None, Some("app")), root) shouldNot include("stage=stage")
     }
 
     "should not contain a stack parameter if no stack is provided" in {
-      instancesUrl(SSA(None, Some("stage"), Some("app")), root) shouldNot include("stack=stack")
+      instancesUrl(SSAA(None, Some("stage"), Some("app")), root) shouldNot include("stack=stack")
     }
 
     "uses the instances path" in {
-      instancesUrl(SSA(None, None, None), root) should startWith(s"$root/instances?")
+      instancesUrl(SSAA(None, None, None), root) should startWith(s"$root/instances?")
     }
   }
 

--- a/test/services/notification/ScheduledNotificationRunnerTest.scala
+++ b/test/services/notification/ScheduledNotificationRunnerTest.scala
@@ -22,7 +22,7 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
     val capi = Owner("capi", List(SSAA(Some("capi"), Some("PROD"))))
     val owners = List(discussion, capi)
 
-    val discussionApiProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("discussion"), Some("PROD"), Some("api")))
+    val discussionApiProd = Fixtures.instanceWithSSAA("arn3", SSAA(Some("discussion"), Some("PROD"), Some("api")))
 
     ScheduledNotificationRunner.ownerForInstance(discussionApiProd, Owners(owners, defaultOwner)) should be(discussion)
   }
@@ -32,7 +32,7 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
     val amigoProdOwner = Owner("amigoProdOwner", List(SSAA(Some("devtools"), Some("PROD"), Some("amigo"))))
     val owners = List(amigoOwner, amigoProdOwner)
 
-    val amigoProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
+    val amigoProd = Fixtures.instanceWithSSAA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
 
     ScheduledNotificationRunner.ownerForInstance(amigoProd, Owners(owners, defaultOwner)) should be(amigoProdOwner)
   }
@@ -42,7 +42,7 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
     val devtoolsProd = Owner("capi", List(SSAA(Some("devtools"), Some("PROD"))))
     val owners = List(amigoOwner, devtoolsProd)
 
-    val amigoProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
+    val amigoProd = Fixtures.instanceWithSSAA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
 
     ScheduledNotificationRunner.ownerForInstance(amigoProd, Owners(owners, defaultOwner)) should be(amigoOwner)
   }
@@ -52,7 +52,7 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
     val devtoolsProd = Owner("capi", List(SSAA(Some("devtools"), Some("PROD"))))
     val owners = List(amigoOwner, devtoolsProd)
 
-    val capiProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("capi"), Some("PROD")))
+    val capiProd = Fixtures.instanceWithSSAA("arn3", SSAA(Some("capi"), Some("PROD")))
 
     ScheduledNotificationRunner.ownerForInstance(capiProd, Owners(owners, defaultOwner)) should be(defaultOwner)
   }

--- a/test/services/notification/ScheduledNotificationRunnerTest.scala
+++ b/test/services/notification/ScheduledNotificationRunnerTest.scala
@@ -19,7 +19,7 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
 
   "ownerForInstance should return the owner of an instance" in {
     val discussion = Owner("discussiondev", List(SSA(Some("discussion"), Some("PROD"), Some("api"))))
-    val capi = Owner("capi", List(SSA(Some("capi"), Some("PROD"))))
+    val capi = Owner("capi", List(SSAA(Some("capi"), Some("PROD"))))
     val owners = List(discussion, capi)
 
     val discussionApiProd = Fixtures.instanceWithSSA("arn3", SSA(Some("discussion"), Some("PROD"), Some("api")))

--- a/test/services/notification/ScheduledNotificationRunnerTest.scala
+++ b/test/services/notification/ScheduledNotificationRunnerTest.scala
@@ -18,41 +18,41 @@ class ScheduledNotificationRunnerTest extends FreeSpec with Matchers with Attemp
   val defaultOwner = Owner("Director of Engineering", List.empty)
 
   "ownerForInstance should return the owner of an instance" in {
-    val discussion = Owner("discussiondev", List(SSA(Some("discussion"), Some("PROD"), Some("api"))))
+    val discussion = Owner("discussiondev", List(SSAA(Some("discussion"), Some("PROD"), Some("api"))))
     val capi = Owner("capi", List(SSAA(Some("capi"), Some("PROD"))))
     val owners = List(discussion, capi)
 
-    val discussionApiProd = Fixtures.instanceWithSSA("arn3", SSA(Some("discussion"), Some("PROD"), Some("api")))
+    val discussionApiProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("discussion"), Some("PROD"), Some("api")))
 
     ScheduledNotificationRunner.ownerForInstance(discussionApiProd, Owners(owners, defaultOwner)) should be(discussion)
   }
 
   "ownerForInstance should return the most specific owner of an instance" in {
-    val amigoOwner = Owner("amigoOwner", List(SSA(Some("devtools"), app = Some("amigo"))))
-    val amigoProdOwner = Owner("amigoProdOwner", List(SSA(Some("devtools"), Some("PROD"), Some("amigo"))))
+    val amigoOwner = Owner("amigoOwner", List(SSAA(Some("devtools"), app = Some("amigo"))))
+    val amigoProdOwner = Owner("amigoProdOwner", List(SSAA(Some("devtools"), Some("PROD"), Some("amigo"))))
     val owners = List(amigoOwner, amigoProdOwner)
 
-    val amigoProd = Fixtures.instanceWithSSA("arn3", SSA(Some("devtools"), Some("PROD"), Some("amigo")))
+    val amigoProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
 
     ScheduledNotificationRunner.ownerForInstance(amigoProd, Owners(owners, defaultOwner)) should be(amigoProdOwner)
   }
 
   "ownerForInstance should return the most specific owner of an instance 2" in {
-    val amigoOwner = Owner("devtools", List(SSA(Some("devtools"), app = Some("amigo"))))
-    val devtoolsProd = Owner("capi", List(SSA(Some("devtools"), Some("PROD"))))
+    val amigoOwner = Owner("devtools", List(SSAA(Some("devtools"), app = Some("amigo"))))
+    val devtoolsProd = Owner("capi", List(SSAA(Some("devtools"), Some("PROD"))))
     val owners = List(amigoOwner, devtoolsProd)
 
-    val amigoProd = Fixtures.instanceWithSSA("arn3", SSA(Some("devtools"), Some("PROD"), Some("amigo")))
+    val amigoProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("devtools"), Some("PROD"), Some("amigo")))
 
     ScheduledNotificationRunner.ownerForInstance(amigoProd, Owners(owners, defaultOwner)) should be(amigoOwner)
   }
 
   "ownerForInstance should return the default Owner if no other owner is found" in {
-    val amigoOwner = Owner("devtools", List(SSA(Some("devtools"), Some("amigo"))))
-    val devtoolsProd = Owner("capi", List(SSA(Some("devtools"), Some("PROD"))))
+    val amigoOwner = Owner("devtools", List(SSAA(Some("devtools"), Some("amigo"))))
+    val devtoolsProd = Owner("capi", List(SSAA(Some("devtools"), Some("PROD"))))
     val owners = List(amigoOwner, devtoolsProd)
 
-    val capiProd = Fixtures.instanceWithSSA("arn3", SSA(Some("capi"), Some("PROD")))
+    val capiProd = Fixtures.instanceWithSSA("arn3", SSAA(Some("capi"), Some("PROD")))
 
     ScheduledNotificationRunner.ownerForInstance(capiProd, Owners(owners, defaultOwner)) should be(defaultOwner)
   }

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -10,9 +10,9 @@ object Fixtures {
     Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
   def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
     amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
-  def instanceWithSSA(arn: String, ssa: SSAA): Instance = {
+  def instanceWithSSA(arn: String, ssaa: SSAA): Instance = {
     val empty = emptyInstance(arn)
-    empty.copy(stack = ssa.stack, stage = ssa.stage, app = ssa.app.toList,  meta = Meta("", Origin("", ssa.accountName.getOrElse(""), "", "")))
+    empty.copy(stack = ssaa.stack, stage = ssaa.stage, app = ssaa.app.toList,  meta = Meta("", Origin("", ssaa.accountName.getOrElse(""), "", "")))
   }
 
   object AMIs {

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -7,12 +7,12 @@ object Fixtures {
   def emptyAmi(arn: String): AMI =
     AMI(arn, None, "", "", None, Map.empty, None, "", "", "", "", "",  "", None, None)
   def emptyInstance(arn: String): Instance =
-    Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
+    Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", None, "", "")))
   def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
     amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
-  def instanceWithSSA(arn: String, ssaa: SSAA): Instance = {
+  def instanceWithSSAA(arn: String, ssaa: SSAA): Instance = {
     val empty = emptyInstance(arn)
-    empty.copy(stack = ssaa.stack, stage = ssaa.stage, app = ssaa.app.toList,  meta = Meta("", Origin("", ssaa.accountName.getOrElse(""), "", "")))
+    empty.copy(stack = ssaa.stack, stage = ssaa.stage, app = ssaa.app.toList,  meta = Meta("", Origin("", ssaa.accountName, "", "")))
   }
 
   object AMIs {

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -10,7 +10,7 @@ object Fixtures {
     Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
   def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
     amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
-  def instanceWithSSA(arn: String, ssa: SSA): Instance =
+  def instanceWithSSA(arn: String, ssa: SSAA): Instance =
     emptyInstance(arn).copy(stack = ssa.stack, stage = ssa.stage, app = ssa.app.toList)
 
   object AMIs {

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -151,4 +151,11 @@ object Fixtures {
         |        }
         |      }""".stripMargin
   }
+  object Accounts {
+    val validAccount =
+      """{
+        |      "accountNumber": "1",
+        |      "accountName": "barnard-castle"
+        |    }""".stripMargin
+  }
 }

--- a/test/util/Fixtures.scala
+++ b/test/util/Fixtures.scala
@@ -10,8 +10,10 @@ object Fixtures {
     Instance(arn, "", "", "", "", "", DateTime.now, "", "", "", Nil, Map.empty, None, None, Nil, Nil, Map.empty, Meta("", Origin("", "", "", "")))
   def instanceWithAmiArn(arn: String, amiArnOpt: Option[String]): Instance =
     amiArnOpt.fold(emptyInstance(arn))(amiArn => emptyInstance(arn).copy(specification = Map("imageArn" -> amiArn)))
-  def instanceWithSSA(arn: String, ssa: SSAA): Instance =
-    emptyInstance(arn).copy(stack = ssa.stack, stage = ssa.stage, app = ssa.app.toList)
+  def instanceWithSSA(arn: String, ssa: SSAA): Instance = {
+    val empty = emptyInstance(arn)
+    empty.copy(stack = ssa.stack, stage = ssa.stage, app = ssa.app.toList,  meta = Meta("", Origin("", ssa.accountName.getOrElse(""), "", "")))
+  }
 
   object AMIs {
     val validAMI = """{


### PR DESCRIPTION
## What does this change?
Adds a dropdown to amiable allowing you to filter instances by account name and updates the AMI display to also show account name. 

The motivation here is that AMIable needs to become a source of truth for all AMIs in use at the guardian - even if they aren't properly tagged - and account name is a piece of information we can reliably have about each instance. Whilst there's been some excellent work done on https://github.com/guardian/tag-janitor we can't guarantee that stuff will be properly tagged, so I'm trying to adjust the UI to allow for this. 

The extra 'account' column causes the boxes to get a bit wide unfortunately, so I've had to give them a max width and allow word breaking in the CSS for the table. I've tried to limit the impact of this by only showing the account column where accountName != stackName

 It looks like this at the moment:
<img width="1208" alt="Screenshot 2020-12-01 at 18 16 53" src="https://user-images.githubusercontent.com/3606555/100782290-1dd5da80-3404-11eb-98a3-73e479a5729b.png">


<img width="568" alt="Screenshot 2020-12-01 at 18 27 24" src="https://user-images.githubusercontent.com/3606555/100781414-e7e42680-3402-11eb-98b7-5f3302523814.png">


Next steps:
 - Use the /stack, /stage, /app endpoints in prism to make those fields dropdowns or autocomplete fields
 - Investigate exposing package level information about AMIs - e.g. "what version of nginx is this AMI running" 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run amiable, check that you can see the account filter, that it works, and that it doesn't break the UI.

## How can we measure success?
Long term, number of out of date AMIs should go down. A proper measure would be to see how many times the account filter gets used, but I think I'll just ask people if they've used it...


## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
