### PR TITLE
Remove PROD filter on homepage instance count

### DIFF
--- a/app/controllers/AMIable.scala
+++ b/app/controllers/AMIable.scala
@@ -18,7 +18,7 @@ class AMIable (val controllerComponents: ControllerComponents, val amiableConfig
   implicit val conf: AMIableConfig = amiableConfigProvider.conf
 
   def index: Action[AnyContent] = authAction.async { implicit request =>
-    val ssaa = SSAA(stage = Some("PROD"))
+    val ssaa = SSAA()
     val charts = Charts.charts(
       instanceCountHistory = agents.oldProdInstanceCountHistory,
       age25thPercentileHistory = agents.amisAgePercentile25thHistory,


### PR DESCRIPTION
## What does this change?
Removes a filter on the amiable homepage that restricted it to PROD AMIs. All out of date AMIs represent a security risk so we should complain about all of them in our tooling! 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before
<img width="547" alt="Screenshot 2021-01-28 at 18 25 31" src="https://user-images.githubusercontent.com/3606555/106182040-3b21ed80-6196-11eb-9985-52423b750adf.png">
After

<img width="573" alt="Screenshot 2021-01-28 at 18 25 19" src="https://user-images.githubusercontent.com/3606555/106182032-39f0c080-6196-11eb-8b46-ebc6b299dc12.png">

