### PR TITLE
Add metric for total no. old dinstances

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -2,6 +2,7 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsync
 import com.gu.googleauth.AuthAction
 import config.AmiableConfigProvider
 import controllers.{AMIable, Healthcheck, Login, routes}
+import metrics.CloudWatch
 import play.api.ApplicationLoader.Context
 import play.api.libs.logback.LogbackLoggerConfigurator
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -44,10 +45,13 @@ class AppLoader extends play.api.ApplicationLoader {
 
 class AppComponents(context: Context) extends play.api.BuiltInComponentsFromContext(context) with HttpFiltersComponents with AhcWSComponents with controllers.AssetsComponents {
 
-  val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment)
-  val metrics = new Metrics(environment, agents, applicationLifecycle)
-
   lazy val amiableConfigProvider = new AmiableConfigProvider(wsClient, configuration, httpConfiguration)
+
+  val cloudwatch = new CloudWatch(amiableConfigProvider)
+
+  val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
+  val metrics = new Metrics(cloudwatch, environment, agents, applicationLifecycle)
+
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync
 

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -47,7 +47,7 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
 
   lazy val amiableConfigProvider = new AmiableConfigProvider(wsClient, configuration, httpConfiguration)
 
-  val cloudwatch = new CloudWatch(amiableConfigProvider)
+  val cloudwatch = new CloudWatch(amiableConfigProvider.stage)
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
   val metrics = new Metrics(cloudwatch, environment, agents, applicationLifecycle)

--- a/app/config/AMIableConfig.scala
+++ b/app/config/AMIableConfig.scala
@@ -36,6 +36,10 @@ class AmiableConfigProvider @Inject() (val ws: WSClient, val playConfig: Configu
     amiableUrl
   )
 
+  val stage: String = requiredString(
+    playConfig, "stage"
+  )
+
   val requiredGoogleGroups: Set[String] = Set(requiredString(playConfig, "auth.google.2faGroupId"))
 
   val googleAuthConfig: GoogleAuthConfig = {

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -28,7 +28,7 @@ object CloudWatchMetrics {
   case object OldCountByAccount extends CloudWatchMetric("instances-running-out-of-date-amis-account")
 }
 
-class CloudWatch(amiableConfigProvider: AmiableConfigProvider) {
+class CloudWatch(stage: String) {
   lazy val client = {
     val credentialsProvider = new AWSCredentialsProviderChain(
       InstanceProfileCredentialsProvider.getInstance(),
@@ -41,7 +41,7 @@ class CloudWatch(amiableConfigProvider: AmiableConfigProvider) {
     acwac
   }
 
-  val namespace = s"AMIable-${amiableConfigProvider.stage}"
+  val namespace = s"AMIable-$stage"
 
   private[metrics] def putRequest(metricName: String, value: Int, dimensions: List[Dimension] = List.empty): PutMetricDataRequest = {
     new PutMetricDataRequest()

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -41,11 +41,11 @@ class CloudWatch(stage: String) {
     acwac
   }
 
-  val namespace = s"AMIable-$stage"
+  val defaultNamespace = s"AMIable-$stage"
 
-  private[metrics] def putRequest(metricName: String, value: Int, dimensions: List[Dimension] = List.empty): PutMetricDataRequest = {
+  private[metrics] def putRequest(metricName: String, value: Int, dimensions: List[Dimension] = List.empty, namespace: String = defaultNamespace): PutMetricDataRequest = {
     new PutMetricDataRequest()
-      .withNamespace(namespace)
+      .withNamespace(defaultNamespace)
       .withMetricData {
         new MetricDatum()
           .withMetricName(metricName)
@@ -57,7 +57,7 @@ class CloudWatch(stage: String) {
   private def getRequest(metricName: String): GetMetricStatisticsRequest = {
     val now = DateTime.now(DateTimeZone.UTC)
     new GetMetricStatisticsRequest()
-      .withNamespace(namespace)
+      .withNamespace(defaultNamespace)
       .withMetricName(metricName)
       .withPeriod(60 * 60 * 24)  // 1 day (24 hrs)
       .withStartTime(now.minusDays(90).toDate)
@@ -99,9 +99,9 @@ class CloudWatch(stage: String) {
     oldInstanceAccountHistory.foreach { oldAMICount =>
       val dimensions = List(
         new Dimension().withName("Account").withValue(oldAMICount.accountName),
-        new Dimension().withName("DataType").withValue("ami/total-old")
+        new Dimension().withName("DataType").withValue("oldami/total")
       )
-      putWithRequest(putRequest(metricName, oldAMICount.count, dimensions))
+      putWithRequest(putRequest(metricName, oldAMICount.count, dimensions, "SecurityHQ"))
     }
   }
 }

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -9,6 +9,7 @@ import com.amazonaws.services.cloudwatch.model._
 import models.Attempt
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
+import services.OldInstanceAccountHistory
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,6 +23,7 @@ object CloudWatchMetrics {
   case object AmisAgePercentile75th extends CloudWatchMetric("instances-amis-age-percentile-75th")
   case object AmisAgePercentile90th extends CloudWatchMetric("instances-amis-age-percentile-90th")
   case object AmisAgePercentileHighest extends CloudWatchMetric("instances-amis-age-percentile-highest")
+  case object OldCountByAccount extends CloudWatchMetric("instances-running-out-of-date-amis-account")
 }
 
 object CloudWatch {
@@ -41,7 +43,7 @@ object CloudWatch {
   val allStacks = "*"
   val namespace = "AMIs"
 
-  private val dimensions = List(
+  private val defaultDimensions = List(
     new Dimension()
       .withName("stage")
       .withValue(prodStage),
@@ -50,14 +52,14 @@ object CloudWatch {
       .withValue(allStacks)
   )
 
-  private[metrics] def putRequest(metricName: String, value: Int): PutMetricDataRequest = {
+  private[metrics] def putRequest(metricName: String, value: Int, dimensions: Option[List[Dimension]] = None): PutMetricDataRequest = {
     new PutMetricDataRequest()
       .withNamespace(namespace)
       .withMetricData {
         new MetricDatum()
           .withMetricName(metricName)
           .withValue(value.toDouble)
-          .withDimensions(dimensions.asJava)
+          .withDimensions(dimensions.getOrElse(defaultDimensions).asJava)
       }
   }
 
@@ -66,7 +68,7 @@ object CloudWatch {
     new GetMetricStatisticsRequest()
       .withNamespace(namespace)
       .withMetricName(metricName)
-      .withDimensions(dimensions.asJava)
+      .withDimensions(defaultDimensions.asJava)
       .withPeriod(60 * 60 * 24)  // 1 day (24 hrs)
       .withStartTime(now.minusDays(90).toDate)
       .withEndTime(now.toDate)
@@ -100,6 +102,16 @@ object CloudWatch {
     }{ value =>
       putWithRequest(putRequest(metricName, value))
       Logger.debug(s"Updated CloudWatch metric '$metricName' with value '$value'")
+    }
+  }
+
+  def put(metricName: String, oldInstanceAccountHistory: List[OldInstanceAccountHistory]): Unit = {
+    oldInstanceAccountHistory.foreach { oldAMICount =>
+      val dimensions = List(
+        new Dimension().withName("Account").withValue(oldAMICount.accountName),
+        new Dimension().withName("DataType").withValue("ami/total-old")
+      )
+      putWithRequest(putRequest(metricName, oldAMICount.count, Some(dimensions)))
     }
   }
 }

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class OldInstanceAccountHistory(date: DateTime, accountName: String, count: Int)
 
-class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle: ApplicationLifecycle, system: ActorSystem, environment: Environment)(implicit exec: ExecutionContext) {
+class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle: ApplicationLifecycle, system: ActorSystem, environment: Environment, cloudWatch: CloudWatch)(implicit exec: ExecutionContext) {
 
   lazy implicit val conf = amiableConfigProvider.conf
   val refreshInterval = 5.minutes
@@ -132,7 +132,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   }
 
   private def refreshHistory(agent: Agent[List[(DateTime, Double)]], metricName:String): Unit = {
-    CloudWatch.get(metricName).fold(
+    cloudWatch.get(metricName).fold(
       { err =>
         Logger.warn(s"Failed to update historical data for metric '$metricName': ${err.logString}")
       },

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -20,6 +20,7 @@ class Metrics(environment: Environment, agents: Agents, lifecycle: ApplicationLi
       CloudWatch.put(CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
       CloudWatch.put(CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
       CloudWatch.put(CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+      CloudWatch.put(CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 
     lifecycle.addStopHook { () =>

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -8,19 +8,19 @@ import rx.lang.scala.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(environment: Environment, agents: Agents, lifecycle: ApplicationLifecycle) {
+class Metrics(cloudWatch: CloudWatch, environment: Environment, agents: Agents, lifecycle: ApplicationLifecycle) {
 
   // only add metrics from PROD
   if (environment.mode == Mode.Prod) {
 
     val subscription = Observable.interval(initialDelay = 10.seconds, period = agents.refreshInterval).subscribe { _ =>
-      CloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
-      CloudWatch.put(CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
-      CloudWatch.put(CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
-      CloudWatch.put(CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
-      CloudWatch.put(CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
-      CloudWatch.put(CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
-      CloudWatch.put(CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
+      cloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
+      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
+      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
+      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
+      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
+      cloudWatch.put(CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+      cloudWatch.put(CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 
     lifecycle.addStopHook { () =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,6 +71,8 @@ auth {
   }
 }
 
+stage=${STAGE}
+
 amiable.mailClient.fromAddress = ${MAIL_ADDRESS}
 
 amiable.owner.notification.cron = ${?OWNER_NOTIFICATION_CRON}

--- a/test/metrics/CloudWatchTest.scala
+++ b/test/metrics/CloudWatchTest.scala
@@ -8,9 +8,10 @@ import scala.collection.JavaConverters._
 
 
 class CloudWatchTest extends FreeSpec with Matchers with OptionValues {
+  val cloudwatch = new CloudWatch("TEST")
   "putRequest" - {
     "sets provided count value" in {
-      val metricDataRequest = CloudWatch.putRequest("test-metric", 5)
+      val metricDataRequest = cloudwatch.putRequest("test-metric", 5)
       val metricDatum = metricDataRequest.getMetricData.asScala.headOption.value
       metricDatum.getValue shouldEqual 5
     }
@@ -27,12 +28,12 @@ class CloudWatchTest extends FreeSpec with Matchers with OptionValues {
       }
 
     "extracts date from result" in {
-      val (dt, _) = CloudWatch.extractDataFromResult(result).headOption.value
+      val (dt, _) = cloudwatch.extractDataFromResult(result).headOption.value
       dt shouldEqual dateTime
     }
 
     "extracts max value from result" in {
-      val (_, v) = CloudWatch.extractDataFromResult(result).headOption.value
+      val (_, v) = cloudwatch.extractDataFromResult(result).headOption.value
       v shouldEqual value
     }
   }


### PR DESCRIPTION
## What does this change?
This PR
 - Changes the namespace of all custom cloudwatch metrics from amiable to include the Stage so that we can distinguish between PROD and CODE amiable (previously there was no amiable CODE stack)
 - Adds a new 'total old instances' metric with 'account' dimension so it can be broken down based off AWS account.

## How to test
This is on CODE at the moment and seems to be working:
<img width="1325" alt="Screenshot 2021-04-14 at 11 05 47" src="https://user-images.githubusercontent.com/3606555/114693332-66d25f80-9d11-11eb-8c65-ccc60843177b.png">

## How can we measure success?
A useful metric in the [grafana vulnerabilities dashboard](https://metrics.gutools.co.uk/d/RHAvkh8Gz/devx-securityhq?orgId=1)

