### PR TITLE
Use namespace if passed to function

### DIFF
--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -45,7 +45,7 @@ class CloudWatch(stage: String) {
 
   private[metrics] def putRequest(metricName: String, value: Int, dimensions: List[Dimension] = List.empty, namespace: String = defaultNamespace): PutMetricDataRequest = {
     new PutMetricDataRequest()
-      .withNamespace(defaultNamespace)
+      .withNamespace(namespace)
       .withMetricData {
         new MetricDatum()
           .withMetricName(metricName)

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -25,7 +25,7 @@ object CloudWatchMetrics {
   case object AmisAgePercentile75th extends CloudWatchMetric("instances-amis-age-percentile-75th")
   case object AmisAgePercentile90th extends CloudWatchMetric("instances-amis-age-percentile-90th")
   case object AmisAgePercentileHighest extends CloudWatchMetric("instances-amis-age-percentile-highest")
-  case object OldCountByAccount extends CloudWatchMetric("instances-running-out-of-date-amis-account")
+  case object OldCountByAccount extends CloudWatchMetric("Vulnerabilities")
 }
 
 class CloudWatch(stage: String) {

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -13,7 +13,7 @@ class Metrics(cloudWatch: CloudWatch, environment: Environment, agents: Agents, 
   // only add metrics from PROD
   if (environment.mode == Mode.Prod) {
 
-    val subscription = Observable.interval(initialDelay = 10.seconds, period = agents.refreshInterval).subscribe { _ =>
+    val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
       cloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
       cloudWatch.put(CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
       cloudWatch.put(CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))


### PR DESCRIPTION
## What does this change?
Send old amis metric to the SecurityHQ namespace. It also changes MetricName to Vulnerabilities, to bring it inline with the other ones.

Although, I've just realised that this is going to deploy tools account and the securityhq ones are going to security. So my plan of using a single query won't work 🤦‍♂️

## How to test
Works in code, I'm seeing the metric come through. But the period is too high, it's coming through every 5 minutes. Security HQ is posting once every 6 hours. Does 4 times a day sound like enough resolution for this data?

## Issues found so far

* We can only calculate how many vulnerabilities are open now, and not present a historic trend. This is because the security hq/amiable metrics have different periods and are not synchronised, which makes it unfeasible to sum the metrics together and present a trend. Calculating the sum of the most recent value of both datasources, though, is easily doable
* They have to queried for in separate queries, since they belong to two different accounts.
* The format of the account is different from SecurityHQ. Example `editorial-systems-development` vs `Editorial Systems Development`. This makes it difficult to exclude the accounts that are not in scope for our work, since they have to be filtered out in two different ways. Also makes it harder to merge data, like sum the number of open issues in sec hq and amiable for the accounts owned by ed tool
* It only posts a metric if the value is different from zero. Which means if we query for the status of an account we get NULL instead of zero.

## Questions

* Is there any way to use the same format for the account property as security hq?
* How can we make it send zero instead of skipping?
* Agree on the 4 times a day?