### PR TITLE
Stop sending metrics from code

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -50,7 +50,7 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
   val cloudwatch = new CloudWatch(amiableConfigProvider.stage)
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
-  val metrics = new Metrics(cloudwatch, environment, agents, applicationLifecycle)
+  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, agents, applicationLifecycle)
 
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -8,10 +8,10 @@ import rx.lang.scala.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(cloudWatch: CloudWatch, environment: Environment, agents: Agents, lifecycle: ApplicationLifecycle) {
+class Metrics(cloudWatch: CloudWatch, stage: String, agents: Agents, lifecycle: ApplicationLifecycle) {
 
   // only add metrics from PROD
-  if (environment.mode == Mode.Prod) {
+  if (stage == "PROD") {
 
     val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
       cloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)


### PR DESCRIPTION
## What does this change?

We have a problem with using the `SecurityHQ` namespace for one of these metrics. There's two namespaces currently for amiable, `amiable-PROD` and `amiable-code`, and each environment posts metrics to their corresponding namespace. This is defined in `CloudWatch.scala` in the constructor. And you can see the problem - by forcing the namespace to `SecurityHQ`, we get both environments sending metrics there, which is not desired behaviour.

Except... `Metrics.scala` has a big if guard clause up top that says `// only add metrics from PROD`, so in theory there shouldn't be any metrics being sent from amiable code.

So the guard clause isn't working. I've patched to use the same data source as CloudWatch to decide if it's CODE or PROD and it seems to work. CODE has stopped posting metrics.

Why are `amiableConfigProvider.stage` and `environment.mode` giving different results? Perhaps fixing that would be a better patch than what I'm proposing here?