### PR TITLE
chore: Ignore CSRF check for sendEmail endpoint

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -16,4 +16,6 @@ GET     /loggedOut                  controllers.Login.loggedOut
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+
++ nocsrf
 POST    /sendEmail                  controllers.AMIable.sendEmail


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We want to confirm the new infrastructure for AMIable CODE defined using the GuCDK pattern is working as expected: have all the right policies been setup etc.

To do this we want to test email sending. This runs on a cron, but we don't want to wait for it to tick over. There's a handy `POST` endpoint that we can use, however it currently has a CSRF check. We don't have a way to get a CSRF token as the endpoint isn't used in any forms, so disable the CSRF check for this one route.

See:
  - https://www.playframework.com/documentation/2.6.x/ScalaCsrf#Applying-a-global-CSRF-filter

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Don't! It will spam people! Although CODE has been configured to always email DevX now.

You can run:

```js
await fetch("https://amiable.code.<DOMAIN>/sendEmail", {method:"POST", credentials: "include"});
```

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We're able to POST to `/sendEmail` and get emails.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/119155714-5e292380-ba4b-11eb-9862-4a247ffced22.png)