### PR TITLE
fix: Only setup scheduled notifications in PROD

### DIFF
--- a/app/services/notification/Notifications.scala
+++ b/app/services/notification/Notifications.scala
@@ -46,17 +46,21 @@ class Notifications @Inject() (amiableConfigProvider: AmiableConfigProvider,
 
 
   def setupSchedule(ownerSchdlCron: String)(implicit ec: ExecutionContext): Unit = {
-    scheduler.getContext.put("ScheduledNotificationRunner", scheduledNotificationRunner)
-    scheduler.getContext.put("ExecutionContext", ec)
-    val jobDetail = newJob(classOf[NotificationJob])
-      .withIdentity(new JobKey("notificationJob"))
-      .build()
-    val trigger = newTrigger()
-      .withIdentity(new TriggerKey("notificationTrigger"))
-      .withSchedule(cronSchedule(ownerSchdlCron))
-      .build()
-    scheduler.scheduleJob(jobDetail, trigger)
-    Logger.info(s"Scheduled owner notification with schedule [$ownerSchdlCron]")
+    if(amiableConfigProvider.stage == "PROD") {
+      scheduler.getContext.put("ScheduledNotificationRunner", scheduledNotificationRunner)
+      scheduler.getContext.put("ExecutionContext", ec)
+      val jobDetail = newJob(classOf[NotificationJob])
+        .withIdentity(new JobKey("notificationJob"))
+        .build()
+      val trigger = newTrigger()
+        .withIdentity(new TriggerKey("notificationTrigger"))
+        .withSchedule(cronSchedule(ownerSchdlCron))
+        .build()
+      scheduler.scheduleJob(jobDetail, trigger)
+      Logger.info(s"Scheduled owner notification with schedule [$ownerSchdlCron]")
+    } else {
+      Logger.info(s"Scheduled notifications disabled in ${amiableConfigProvider.stage}")
+    }
   }
 
   def sendEmail(): Attempt[List[String]] = {


### PR DESCRIPTION
Easiest to review [w/out whitespace](https://github.com/guardian/amiable/pull/65/files?diff=split&w=1).

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We're currently duplicating scheduled emails (once per stage).

This makes inboxes quite noisy.

This change reduces the noise by running the schedule in PROD only.

If we want to execute the sending of emails in CODE, we can do this manually via [`POST /sendEmail`](https://github.com/guardian/amiable/blob/8b0ecfc596eb76a29fe984076c57ab38970c2c33/conf/routes#L21).