### PR TITLE
Sort aws account names in dropdown

### DIFF
--- a/app/views/fragments/ssaAmiForm.scala.html
+++ b/app/views/fragments/ssaAmiForm.scala.html
@@ -8,7 +8,7 @@
             <div class="input-field col m6">
                 <select name="accountName" id="accountName" value="@ssaa.accountName.getOrElse("")">
                     <option value="" disabled selected>Choose AWS account</option>
-                @for(accountName <- accountNames) {
+                @for(accountName <- accountNames.sorted) {
                     <option value="@accountName">@accountName</option>
                 }
                 </select>


### PR DESCRIPTION
## What does this change?
Supreme UX improvement to the dropdown list for selectinig which AWS account to look at - alphabetical order! 🥳 

## How to test
Deploy to CODE, verify order of list and that the  selector still works.

this is the list right now:
<img width="561" alt="Screenshot 2021-06-10 at 14 02 30" src="https://user-images.githubusercontent.com/3606555/121529660-88d81d80-c9f4-11eb-97ac-5d7c98abde0b.png">
