### PR TITLE
Always include every account, even if it's zero

### DIFF
--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -108,10 +108,11 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
       accounts <- Prism.getAccounts
     } yield {
       val now = DateTime.now
-      val amisForAccount = instancesWithAmis.groupBy(_._1.meta.origin.accountName.getOrElse("unknown-account"))
+      val oldInstancesForAccount = PrismLogic.oldInstances(instancesWithAmis).groupBy(_.meta.origin.accountName.getOrElse("unknown-account"))
 
-      val oldInstanceCountsByAccount = accounts.map( account => {
-          OldInstanceAccountHistory(now, account.accountName, PrismLogic.oldInstances(amisForAccount.getOrElse(account.accountName, List())).length)
+      val oldInstanceCountsByAccount = accounts.map(account => {
+        val numberOfOldInstancesForAccount = oldInstancesForAccount.getOrElse(account.accountName, List()).length
+        OldInstanceAccountHistory(now, account.accountName, numberOfOldInstancesForAccount)
       })
 
       oldInstanceCountByAccountAgent.send(oldInstanceCountsByAccount)

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -111,10 +111,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
       val amisForAccount = instancesWithAmis.groupBy(_._1.meta.origin.accountName.getOrElse("unknown-account"))
 
       val oldInstanceCountsByAccount = accounts.map( account => {
-        if(amisForAccount.contains(account.accountName))
-          OldInstanceAccountHistory(now, account.accountName, PrismLogic.oldInstances(amisForAccount(account.accountName)).length)
-        else
-          OldInstanceAccountHistory(now, account.accountName, 0)
+          OldInstanceAccountHistory(now, account.accountName, PrismLogic.oldInstances(amisForAccount.getOrElse(account.accountName, List())).length)
       })
 
       oldInstanceCountByAccountAgent.send(oldInstanceCountsByAccount)


### PR DESCRIPTION
## What does this change?
Report metrics for every known account, even if the number of old instances is zero.

This makes it easier to plot the data.

## How to test
Ran this locally!