### PR TITLE
Bump `sbt-riffraff-artifact` to v1.1.17

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
 // web plugins


### PR DESCRIPTION
This version includes changes to enable CI with GitHub Actions.