### PR TITLE
Update @guardian/cdk dependency to 26.2.1

### DIFF
--- a/cdk/bin/amiable.ts
+++ b/cdk/bin/amiable.ts
@@ -10,5 +10,5 @@ new Amiable(app, "Amiable", {
   migratedFromCloudFormation: true,
   stack: "deploy",
   env: { region: "eu-west-1" },
-  stackName
+  stackName,
 });

--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -48,11 +48,6 @@ Object {
       "Description": "The sender of emails sent using SES.",
       "Type": "String",
     },
-    "InstanceTypeAmiable": Object {
-      "Default": "t3.small",
-      "Description": "EC2 Instance Type for the app amiable",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -175,9 +170,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIAmiable",
         },
-        "InstanceType": Object {
-          "Ref": "InstanceTypeAmiable",
-        },
+        "InstanceType": "t4g.micro",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
@@ -817,11 +810,11 @@ Object {
     },
     "TargetGroupAmiable6987B5AC": Object {
       "Properties": Object {
-        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 10,
-        "HealthyThresholdCount": 2,
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
         "Port": 9000,
         "Protocol": "HTTP",
         "Tags": Array [
@@ -848,8 +841,14 @@ Object {
             },
           },
         ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
         "TargetType": "instance",
-        "UnhealthyThresholdCount": 5,
+        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcId",
         },
@@ -876,10 +875,6 @@ Object {
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "amiable",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -1,7 +1,7 @@
-import { Peer } from "@aws-cdk/aws-ec2";
+import { InstanceClass, InstanceSize, InstanceType, Peer } from "@aws-cdk/aws-ec2";
 import type { App } from "@aws-cdk/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
+import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuAllowPolicy, GuSESSenderPolicy } from "@guardian/cdk/lib/constructs/iam";
 import { AccessScope, GuPlayApp } from "@guardian/cdk/lib/patterns/ec2-app";
 import { GuardianPublicNetworks } from "@guardian/private-infrastructure-config";
@@ -20,6 +20,7 @@ export class Amiable extends GuStack {
 
     new GuPlayApp(this, {
       app: this.app,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
       userData: `#!/bin/bash -ev
 
           mkdir /amiable

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,12 +17,12 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.115.0",
+    "@aws-cdk/assert": "1.122.0",
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0",
     "@types/jest": "^27.0.0",
     "@types/node": "16.4.13",
-    "aws-cdk": "1.115.0",
+    "aws-cdk": "1.122.0",
     "eslint": "^7.32.0",
     "jest": "^27.0.6",
     "jest-teamcity-reporter": "^0.9.0",
@@ -32,13 +32,13 @@
     "typescript": "~4.3.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "1.115.0",
-    "@aws-cdk/aws-ec2": "1.115.0",
-    "@aws-cdk/aws-elasticloadbalancingv2": "1.115.0",
-    "@aws-cdk/aws-iam": "1.115.0",
-    "@aws-cdk/aws-rds": "1.115.0",
-    "@aws-cdk/core": "1.115.0",
-    "@guardian/cdk": "23.3.0",
+    "@aws-cdk/aws-autoscaling": "1.122.0",
+    "@aws-cdk/aws-ec2": "1.122.0",
+    "@aws-cdk/aws-elasticloadbalancingv2": "1.122.0",
+    "@aws-cdk/aws-iam": "1.122.0",
+    "@aws-cdk/aws-rds": "1.122.0",
+    "@aws-cdk/core": "1.122.0",
+    "@guardian/cdk": "26.2.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2,712 +2,768 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.115.0.tgz#31ac7667c7ffc658ddf816f774dcb2cc390afcf3"
-  integrity sha512-sOSo2xFLFA/lFWOmsDllMgxDwxv6VuPfi7FueizlgdLZLaRyctEWH55rGm07C+ewej1AjFHp2mjp0SSpG2V3Cw==
+"@aws-cdk/assert@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.122.0.tgz#30a78c0784aff0ec57239a862c8d266f9f9ffd10"
+  integrity sha512-hgmN7Owmsk9F7rGsvD4LjhY7YukgMpKWNvbXHxsTSluoP2LF7MRwTcYu2bf/DAkYuY7tK1X8k0G4jeEZAie4ZQ==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/assets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.115.0.tgz#e27c54cc032d3921fd841b5054eed5d68737b8a7"
-  integrity sha512-bZlT7EU7qDKqCO5QSYRnBHS4QWFpCwBuXpuxtKj0dAkoMYghhp/d2N6vJbvdeYJp171dfmEZvGYcGM1eyI9xkg==
+"@aws-cdk/assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.122.0.tgz#58c1a34ce4ae59fdf33a9d4dc2f384c1850acae5"
+  integrity sha512-jNY/nXEWtoIONZnXfRr22i8PVp2JPDai4hofzu2/vnwZuJF+a+BlEI3yWzXaQMZ7ZNMnT0KSXwkaSque+1xr3g==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-apigateway@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.115.0.tgz#56cf930d0adadcd2ed36f3810253462a441ca095"
-  integrity sha512-/szXz2CGoTwZFSbuRXIeDYPe238LCzS2S2ZgCWt6Y26ok13+jCv/i5Sq0Oqj3sj2fYXTf5lZbwQKSvV/yo21vA==
+"@aws-cdk/aws-apigateway@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.122.0.tgz#5f2a1e3f5b7fedc951bbd4e25117d0954f4cfdfe"
+  integrity sha512-rJlocumxO+9uvEMrLc0iUxcq0jfn/+ckvJX76TsRr7ptXO8ydfEfwBcZjNtX0ypDOv6QShZH6KbqiZimgp/GbA==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-cognito" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-applicationautoscaling@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.115.0.tgz#f84a217567a31ffb59ba6edd689ae48178b0f0cb"
-  integrity sha512-s/n0cUpmabM3RAJ86S4EEJgmA1fkGhH/ntMJfgUwhDZyJsa1WUfWxVVxt+ZCjJ7fNl6ZveZHqlsLCnsbSf9Ogg==
+"@aws-cdk/aws-applicationautoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.122.0.tgz#25330a0185cf9df77499677b528b260ca6db441d"
+  integrity sha512-iLXCGgQPfkL/bSIbtJXN5VlEqLyK/mnu+y8TtSsZ6ls0o3et1vHSZoVZvbtmlXdP/F+MF40rSwKqVrU1cMb70A==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-common@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.115.0.tgz#4ff1f554bad5dcedc2a9aa7bc0e91993e7638bd6"
-  integrity sha512-5L/DgfqHfX4Vwa2g42vxA0ZNxuwtIEnjxX3R+tZkppvvZYrKJIFAkjbD21x6eXv3N6Kckmd8+fdQCV8N4p7Hug==
+"@aws-cdk/aws-autoscaling-common@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.122.0.tgz#fb001f5b85b927063dc5dd4c28c4534127cae251"
+  integrity sha512-vTkBJGOHKr16S+4XOhkqvHfzapSKVJ+eHe599B2imhC5n3hui/ly6jc0aUGXT8r2yIUqGYuqVJLVW0OlHZRjBQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling-hooktargets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.115.0.tgz#9eae8c1fb02d4672fad1b045350587cd3c5a100e"
-  integrity sha512-xo53X0BWXPOkp8r+XIQuMAK1Ry4EBc+LFiRxrqRpZPxQrXLeX0pxwZmiwqppOC6Ew4j04IluvJ5lyrlEOk+L6Q==
+"@aws-cdk/aws-autoscaling-hooktargets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.122.0.tgz#33e2615b75a013d3d2f043bb7211aef8d1dffac1"
+  integrity sha512-4oDw8zveuEMUmOYZQ96cAVVw8o9tM1BEN1Jb+Yul+GVw2xJPzHMxbDn3IKvIqu+dL/9dabK0fq5Tpve74RHb1A==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-autoscaling@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.115.0.tgz#41be56a6535dd9cca54b137b0275ef6d5dbf7082"
-  integrity sha512-ZwZ1N2LZ3R1MeiOp1Le0tx6EQHqX+3qDh/R084YqF7/PUmnORSzvOAZX0CXD8NS2okTZKgh9w5TAltVBcI2pVA==
+"@aws-cdk/aws-autoscaling@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.122.0.tgz#d4c8f5b02306c3371279ab601dbd6b2ad7b8d4ae"
+  integrity sha512-K/DNeCMxRNhtksOW6JIVDcng8FSnGQHV6ScTnYTUeJGOJpNgwF/pB+nW3Bmw4w/QNyt5lN9DnHs6NIYZjTDMCw==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-autoscaling-common" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-certificatemanager@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.115.0.tgz#10f0bdca79cd897297ffa0015cab7708bba7fbb5"
-  integrity sha512-c38QRpbkYUay+bO0pzTDgWZRtiJRX6qqi5W2ZKjY+DMnGXHDXZ9KLP1tknLdKJoDpfsqYao7W962zbUUXdNCYA==
+"@aws-cdk/aws-certificatemanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.122.0.tgz#f2eec2a41a48998667e5d5578047a4f1d9e60e9e"
+  integrity sha512-ULrOt7JJWBisQz9ImjXQT/lSvOHobNqBGLP8nXTltlIktPO1oqdtcqJGYq0+XXXRz99xmw6O9K5raDpAc/eKIQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-route53" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudformation@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.115.0.tgz#c2e09ad6e13e2cc7c640adc4a06c4747296995f3"
-  integrity sha512-7Dc7JPBwpoi5hxO4VeamecJFSuwo8Wull4iv4MgA6Jz3vIZCE3cD5EkwzreoU9yRkcHuehsJ9NBc0HY8nwTC0g==
+"@aws-cdk/aws-cloudformation@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.122.0.tgz#b077151c001571188688678c86e3053ae64b52a1"
+  integrity sha512-ohI6cKwqd7YuibyvBGn9I0V8hf0MU1uHQvNRBy3teMMXOVwUrJbGKeeA5uBppAlJFmGanUpgiScEOJW9FvKW7Q==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudfront@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.115.0.tgz#6476560b4976c1d211f607c98c4f916ec29bac82"
-  integrity sha512-ySXhMXRoMqDJrL5Gk8YtSdGl/fAMTUc7musTUA0AsxV+hInHluKoUA15I73Jheil2KyY3mzwZyFNG1qgvZVvpA==
+"@aws-cdk/aws-cloudfront@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.122.0.tgz#2e8ce364e725d24652a2d200bfb6c28c131810a9"
+  integrity sha512-JpX2ad/EEGLUuW9guOxDChBdIzWHFG/tx6XKBO0XKgoZ/4Yqvz8CLtA0lSet5hLbly11TmKHZcCm/FoqjUj1Jw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-ssm" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch-actions@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.115.0.tgz#bcfaa6144b8e8fbbabaac0d737bfe588c709879d"
-  integrity sha512-ZcsdkRbrwAzWFKHDhMQ0RHe2BmjrqmZubGYTtY+OhKpRAeHlkhOEZ9aFDhypYZMGjL12EICuNmiWldfh8MV0Hg==
+"@aws-cdk/aws-cloudwatch-actions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.122.0.tgz#dc9a53dd8fae83bc4f88143a9ddc238da3712526"
+  integrity sha512-QDipB9lZY2P9rnn51oaIriVASdfIF3Ymh5JizpThthFxDubCtkJul0jUbbp3ZM6kQ4ILS9X7tlAD7waNvmh5hQ==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.115.0"
-    "@aws-cdk/aws-autoscaling" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.115.0.tgz#7531a318a9fc7090665b52fd73a0dde4e22a3745"
-  integrity sha512-HmlwnQ76/z/ka4S5Jwm+KXHGp4FAB9rcE3G0l2pP71lYGn4XH2Z66jUZb/U2yixCCwx1oLYZZtcU4d4FRGaI5A==
+"@aws-cdk/aws-cloudwatch@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.122.0.tgz#25724ce559e423f498247b8821fa1564a0f94edb"
+  integrity sha512-K7kFyc5MlWTBTxQrNg32DZWGJoYXTKxjc/5i5HJBPYPNOeG+joK+3fFiG9seBmea4O3xYMHg7vbuZxcvM7AbSA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codebuild@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.115.0.tgz#d7586ad3e3c05e782cab6a8550bee4a4701491e2"
-  integrity sha512-4kgGuWEF5bBqh5hNZfSzRke/LS3ShfvraaF5Z0snYN8Qa1sb9162nCDkdavtYnDTgAQm7IRybQjTMlFeD+NM6A==
+"@aws-cdk/aws-codebuild@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.122.0.tgz#5f8fabb9fc3ecb0359b5c26f6254b3bbb821338c"
+  integrity sha512-Wa73Y02E7LNCHAm76KnJJEikC8HuX8symoVlR9YhZnqFhG3CbynpCgzlNZIhObiUaU2u5L9r8WT3hyYK/QfN8Q==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-codecommit" "1.115.0"
-    "@aws-cdk/aws-codestarnotifications" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-ecr" "1.115.0"
-    "@aws-cdk/aws-ecr-assets" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/aws-secretsmanager" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codecommit" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
     yaml "1.10.2"
 
-"@aws-cdk/aws-codecommit@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.115.0.tgz#9b5ea9776f6fcb1c4909aea1f2eee5c7f02de6fb"
-  integrity sha512-IhsQOxFy6g3AmKun7Ypxuz7e4CO7amkm+RNkCZfje43qQC1ZU/WT5I6YGUtWtNpCJwLSDtv6RYtXDQIMLICjWQ==
+"@aws-cdk/aws-codecommit@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.122.0.tgz#60da47c1465eec26d209b8ef908712c9f0b56ed1"
+  integrity sha512-vAMNkNZ5YRI/kgAX+sm3g7E0yLWHAhCFLHnTdBPTtefDxwYudP/csdKBiVOHWh+beB4pJugVLn7jPxwyB2Jc5Q==
   dependencies:
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codeguruprofiler@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.115.0.tgz#a2361cdbfa4c87abdd8d8501cca3822ea0023a6c"
-  integrity sha512-SZ2Y22+nquOdqQCXUdTvEeArwhF08Bw8+IzCujl/lghmntbCOiiE0uMtzEzEAt9TJW6T75q1aUmd1b9+1Xh+dA==
+"@aws-cdk/aws-codeguruprofiler@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.122.0.tgz#59770d5c7dfffb8abd156a75cef2df8a3f1a6fda"
+  integrity sha512-gwMtyzr2EjvmOuzIPSM2ooUscmGZnhh/B2Zvjrl28/4UAH6EM2kOGdnZtbzFOzUqT5XqsttVfKycPFNYQscmJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codepipeline@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.115.0.tgz#112ec7fa6500847ad5374968502fbf6d5c5e729a"
-  integrity sha512-3ow39DuZNF2oM7aTpXbCMZ4700/sQ81v7kb6t605UKnmDKiRInEq3x1UxrIyL7B+B1W+YK+dhNDInYxxQwE4VQ==
+"@aws-cdk/aws-codepipeline@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.122.0.tgz#49c08fe31c2b0fb36c0c62c09b32641ecac792c1"
+  integrity sha512-oLF58W3e3e32DICIFg+d+Qf5bM1wXA8TXYtNdUVDXKPCgt7Lyd+aqxlYATFrCSAhjrdjoy2Vj21x9WF8tLRzZA==
   dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-codestarnotifications@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.115.0.tgz#4c8dfd94476a411ab26cc4748f1b39fcdc1a235e"
-  integrity sha512-qR31jrDEkwI74HMAy0mHDgVTxS9zYbZEWAm2qAs/4rtymOTDsT849doV2MEb3Pl1/nLzYfffQWAHwfVQ7gPzig==
+"@aws-cdk/aws-codestarnotifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.122.0.tgz#92049ba8eb6a54a61210506ae6dd0f3af6a83be7"
+  integrity sha512-STdYT94spdxtaODanwW5M0W6V9kaJ9szpPQubYXTKnpKxZ6UCKANKMj+Fqp/zJxlXQqnuaHuMtol0nA/Xt2bfg==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cognito@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.115.0.tgz#9fabc9d2afe00c250314c5a5152ed0aeef31ee50"
-  integrity sha512-GIg79AhiVJzbf+EY8lZaQWXnMZS7FQDM4iB4bOHXbSwyQKwXdODf0Ckaz4lnLRuhZgzs1K+usdHZwJPysjtylw==
+"@aws-cdk/aws-cognito@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.122.0.tgz#a18d1274cbb0d240e365c7edc23b8c1fad1ecf13"
+  integrity sha512-eFdW890ZLaN5c7qQ0/RqQB2Ufta3aQC5tnJzGdkEb9JQfoM/fSL0s+jmpriUHUaD0wok9la34gPq7iKq55B29g==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/custom-resources" "1.115.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
     punycode "^2.1.1"
 
-"@aws-cdk/aws-dynamodb@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.115.0.tgz#f987a403978ccba937d85219d42d9f9fea108412"
-  integrity sha512-rBHszc4KA1xYy3xQgYDCke0wQbTrK7DPjB/SOzt2qRHH4zPcXJYriNdlyjBjGNzzjRlwU3MRO1S6PlUMHM/Jrw==
+"@aws-cdk/aws-dynamodb@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.122.0.tgz#d2402d1cae815910c6a89682dc4ae8978779eec7"
+  integrity sha512-zsEMFxKMxVoa3vyOP4zWD09rXaGKXbAHXhtjhY8MeupDE42ZrspZLybMHycElCVwq8JQjcq0G0oBzOodR6NnPw==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kinesis" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/custom-resources" "1.115.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ec2@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.115.0.tgz#a908ae4889b2ba3c90eb082f11bde107ec5c08e3"
-  integrity sha512-u/UkleFEbzxJzjpu1w5z0gj1cu3+w3yAMaqfR/D9etHsyF4uTtkshuiETmGrBVAdOddaUFQWB3i1wjwfcvyxsg==
+"@aws-cdk/aws-ec2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.122.0.tgz#31b2280629404a829eb639e8e373221613a1aded"
+  integrity sha512-bKJGgd3KruFeOyP/5Fc/Ufr4BHB9+xVpXVGqCeKEInkq0f4ttWhHbfKRJdYEUBEF0xwDQEj7RM6EgaV0fdfb9g==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/aws-ssm" "1.115.0"
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecr-assets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.115.0.tgz#257752d87018281f362a7d4ce5578f4c48e50462"
-  integrity sha512-WmQVWyS5DDS0I8A+LCk86MKEmxji30ocbq+JNeusTwFkIsVL0gaW1AgtCS98GDifjUNxdSU7MgkcCBTCAGRl4A==
+"@aws-cdk/aws-ecr-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.122.0.tgz#6483e869202c272f83e37b7c5003a5b1d4d14813"
+  integrity sha512-BFYCNsUs/1Dlh41bXmFmq41RpNatqm/KHfIWA0eFNIAuG/IqOga9LF71zCBiqv4gfNmfGQg19Sq2BojGQwisVA==
   dependencies:
-    "@aws-cdk/assets" "1.115.0"
-    "@aws-cdk/aws-ecr" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-ecr@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.115.0.tgz#dff8ec3717b12447cc53dd676d714c3aaea47876"
-  integrity sha512-vS2P3y8ArlCY6id1G8i9V6CuRorR+G3VMAUDCqkLc5C35OjtiKD9iY7S6zH/eaX+kDpsd71A1IZ/Qw2dmUGdWw==
+"@aws-cdk/aws-ecr@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.122.0.tgz#a86a52e32d74cd48dc96f7b7613b7151213ea8e6"
+  integrity sha512-FxM7Q/6VHquOdfWrKQArzs/91fxvZFwT/FkPIrEm+X10/voOFI6S6xRXaOlr2UVn6dji6J6DssY7YBvJq1ciOQ==
   dependencies:
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ecs@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.115.0.tgz#c5cce21a0acfb5753541d7f7cea2c9ab2f7f05d5"
-  integrity sha512-QAT4AfQqXAdpK8LS3MsXIOFxHxVDJBRcTYo137+QgkSZqO13qnlf55Edf1ZL3wlLUe7CDZdDdMdcW5Vq4yP4pw==
+"@aws-cdk/aws-ecs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.122.0.tgz#6d7e4c34a4e28881bb94e9f43762653c9fbff208"
+  integrity sha512-SdgRi3TsAOGigVga1HRiTsMlbkC5nosmQJ1P67rF2IcXdhoToKLFrXSLskFsO50JjmK6781efhW6xZYvvTlQ/A==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.115.0"
-    "@aws-cdk/aws-autoscaling" "1.115.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.115.0"
-    "@aws-cdk/aws-certificatemanager" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-ecr" "1.115.0"
-    "@aws-cdk/aws-ecr-assets" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-route53" "1.115.0"
-    "@aws-cdk/aws-route53-targets" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/aws-secretsmanager" "1.115.0"
-    "@aws-cdk/aws-servicediscovery" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/aws-ssm" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-autoscaling-hooktargets" "1.122.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-route53-targets" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-servicediscovery" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-efs@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.115.0.tgz#4311d15cd6a639a40235ffd30697207683bfa40f"
-  integrity sha512-EK/wO9hM3mcSbmmsHxEPX66sblNebQzQ3jpx8Glzn/LYWgNDbMhWvfe+/8WWRhNp5o+0TgmVFOwgYGDtygytgQ==
+"@aws-cdk/aws-efs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.122.0.tgz#b0fba574ccc35f4c6989828f2234c88b8e8e6566"
+  integrity sha512-CFvqAVv2BX31j+tGxM2a8CaTbf2QqMoeegORRJzipykeX+wCPu/5nYA7jWOXlCLYZ2MnLRHaAZzzVtLRvgNSWw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancing@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.115.0.tgz#35b371be142214942bcb16456289f0331d750ecb"
-  integrity sha512-IWhAdrjvbpf7YYqC0zRX/8QOnK13HsSOQRyUfrmchAho3Fik9H1Z8xH3JT6ae2Vr7TRe2R9xArKcUSdsg+crDw==
+"@aws-cdk/aws-eks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-eks/-/aws-eks-1.122.0.tgz#25113b3d6ad4804224cf95310f1bb5b1a082501c"
+  integrity sha512-/T876MGxQD6D9o4C6wlHoZjqYxnxU0Iw7O1fKzp4tW0A+F3ykLwls9QcYDxZlIfSEFzLhNKSKFBp8Lrfx0hHxQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-ssm" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
+    "@aws-cdk/lambda-layer-awscli" "1.122.0"
+    "@aws-cdk/lambda-layer-kubectl" "1.122.0"
+    constructs "^3.3.69"
+    yaml "1.10.2"
+
+"@aws-cdk/aws-elasticloadbalancing@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.122.0.tgz#b96ca26fae657fe1ad3d4fc86bdabe17b11176f7"
+  integrity sha512-LdGcPIp60QLP0SGfgQlJ4N05NT7SCjwzZ3n194+bKlEs/SZ/3KdyCMg4yGKbg9MxcvOV3ADBO7JEy1oEc/b8Sg==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.115.0.tgz#67c5859d2beea6f41bbc8bf8de3092288e7f7138"
-  integrity sha512-q1IKl7jDEtmY7eiZW/7CkHLzh02CNtcg/LcpO0NL16toslfa7zcsRIlNDc2j50Grhft+HBjNsBGy+B5RFEbFzw==
+"@aws-cdk/aws-elasticloadbalancingv2@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.122.0.tgz#3fa95a24c303c44ebc7bb2c15a3289f6197a8c53"
+  integrity sha512-WilvbbVtulDBI1QV2uqd7vlCUKvjjDR6t+WvbaB6iNHyGLcuRF8Gs7aOiIkTbZorkzL68GrKlXmu/oj9dolVHw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/aws-certificatemanager" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events-targets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.115.0.tgz#e887193e15cb1ec827328ec62fd6baef6ed110ad"
-  integrity sha512-7xXcQf0PZGlu5CjKG17igEVQg5laGAdKPcKUCgPQqPK0QK0VwFNT8DJLU5weoiBaRi/JHL3kJ7RW/0RAmn1xOg==
+"@aws-cdk/aws-events-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.122.0.tgz#7757e1e97b94e4c0274fa8b209555efeda823851"
+  integrity sha512-tgBZBQWzt2ePhoVjbpRHnAmCnpJEgjuEn6bAyjpGT6ucjzuL+l3gJDDbth2c3B74eJQB9N5FQ+RXq3coTaqiew==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.115.0"
-    "@aws-cdk/aws-codebuild" "1.115.0"
-    "@aws-cdk/aws-codepipeline" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-ecs" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kinesis" "1.115.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/aws-stepfunctions" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/custom-resources" "1.115.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-codepipeline" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kinesisfirehose" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.115.0.tgz#df146461b3923f3c7eb10d9472b27b3d5143267e"
-  integrity sha512-fpEjk2PAmZk9Kc5lGMbjeWGDVUO4FreKEcoKCgvTQA89eBB16QBK+psdf9nOa5uEj4obOvQ1VENPc3LByyOslA==
+"@aws-cdk/aws-events@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.122.0.tgz#c128fc8b9fd65e82128dcf095b3f25a250c62b8a"
+  integrity sha512-Nc6flYv4Z0P6yK0rIhuUnjsOVEucgv0WdV7va3WzPzp8B253ea0XdLfpSJxGArKAH6qcmCJmd07ls+N2omzFBg==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-globalaccelerator@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.115.0.tgz#5586e2b5af62e0832a6cc101b1cbf10c81a6422e"
-  integrity sha512-KNQev8PXjvSAcMrKUXH0c+jgF/0PkToqs1yPBrydPWKuxEZAEnfxToQ8/Bgfq9gIk71olNJvpQQAzMsxOi4MBQ==
+"@aws-cdk/aws-globalaccelerator@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.122.0.tgz#42da4ba7998919be7b681a4c36f2c44d9482b4c4"
+  integrity sha512-9fwf7nR91bKce7u0aIS7OdVVJ52KC98OfhVO7cTTGS8YHjEnHZIpmNvNWgA3KMinpsMuqiIRIWJrhj2GREis6g==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/custom-resources" "1.115.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.115.0.tgz#0a7a3834757a1cb11cf74e5d6feb930a07261dc0"
-  integrity sha512-NvY2kBe/iepCOWhKI4h31kxqjjN0+jtb1R4zH6GPH2qC0X/+ZaxP1OBOsO3yHluTtsFf/h4SdYjz9ukVTzEm8w==
+"@aws-cdk/aws-iam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.122.0.tgz#6e9bae183c20e554f9044dbadc1815bc4e01510d"
+  integrity sha512-IGPA+m45NFZijzRgXpKeKemt2+8Yba7Se1ru1/h7t2obhpdw/tcsTLhkBVagWGjSyw7zfVDIEJZTe5y5lxyQbw==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesis@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.115.0.tgz#8c6ca1d646255f7c02504353e5bc86c37a2916b6"
-  integrity sha512-Za02x5UmWPYu2jUuIekxV08B1vsGab0y9AQPYlagtjcytBVqGhIN30f5KklHwVJTZ6JFF9wzM0cGGsiexJM1Hg==
+"@aws-cdk/aws-kinesis@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.122.0.tgz#611fd4fe5b9b62095376f5ee31ea25222fbe7f56"
+  integrity sha512-Jfjcon4IOKJOoFJ1W6aqmc/mDmSWWPx0pB6CIW4nPY4/bHEYvyVnxexTiZW0aG3ucdaur6atDc+DVqo2quyVAg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kinesisfirehose@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.115.0.tgz#bbd33bae07fb3847b6f160a5e993a2a74a7bd4a1"
-  integrity sha512-NcrFKFbVjEp1TFdgib4MUttTeGcUWihq7ELzX9UYyMDvoxLUxnpzfIXF1c79MKEC2KhsZVIuwqxabVRMMEHlEw==
+"@aws-cdk/aws-kinesisfirehose@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.122.0.tgz#0aa9954d153e99679c70a6f4b63d8da34dc0b72a"
+  integrity sha512-n7++SIJe0Xpc33gEBrUuxNj5EK0vzhEvELmdTYA6s1gEqjcslEZQzliziwCtlzwsz7G91JCMTrjdc8/0yzofKA==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kms@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.115.0.tgz#0d6bc269262cdc798b358c53f9b4fc2da372f1ba"
-  integrity sha512-aaiXYlNKGfB2UpyoBWm1iyahULowfnwBPYUrDKT79VMaHZXF+znVPnRd/qWnmBSy0ta3igdTRIk7V0lvOMsyjg==
+"@aws-cdk/aws-kms@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.122.0.tgz#0c9710a2ea4828725a4a7fac802a130c8cd9333e"
+  integrity sha512-oVaHgb5L4MXVt/mb1HpDr1dgVuyBNjbVe2To8WOuY1Iah6on7dh725479IObSw72lLS/5STo8XOAGKZ9h0aobA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda-event-sources@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.115.0.tgz#b1e29176584c5a792b36272e2172ba5a00d98fec"
-  integrity sha512-EZV1ik2u3d6I0eKAdnPvyXuys2DxsQVMk/3TSMIb3OtuFsUSGgqpXLt6csl3a/+a4MofwoQ7XfV53ZXm54WVrw==
+"@aws-cdk/aws-lambda-event-sources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.122.0.tgz#f472c5dbb22c1be074d8f72d1b7aa4a93a3b7c82"
+  integrity sha512-1ftiIwds4AVUjkrCGgkNWqXtL4CDtWaQO7zRdQMZ/7uX25ZjtospJUiPIK6ZILCX/mSYTJtUEQqnMsbuTvqPRg==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.115.0"
-    "@aws-cdk/aws-dynamodb" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kinesis" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-notifications" "1.115.0"
-    "@aws-cdk/aws-secretsmanager" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-notifications" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sns-subscriptions" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.115.0.tgz#f9f0765ccbc9ef07bf9a7d3160036d4780f3f35e"
-  integrity sha512-K+emBDwQCbh/B8aSkE8M5MC5bkTEXOYPbR5TaD2dWE7DpHaNJ4eSF5CG2s+DjvRUg3FCC3h7qL56WEqFDjsyAg==
+"@aws-cdk/aws-lambda@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.122.0.tgz#1a870272770f0454235bf394c063c556bbc13c4a"
+  integrity sha512-tAJqGEfyrdVebq99V5vCYg8y/6lhcRlhIbSPRn4h3tKzkSfOhiXqRZD+0qfBA1nF6l64oWI5K+Y2N3DyQEemXg==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.115.0"
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-ecr" "1.115.0"
-    "@aws-cdk/aws-ecr-assets" "1.115.0"
-    "@aws-cdk/aws-efs" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/aws-signer" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codeguruprofiler" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-efs" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/aws-signer" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-logs@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.115.0.tgz#21a105980a3c11a0ac59619e5f120fb53d4876a6"
-  integrity sha512-gMktp1+IZ5hvaudmTm/RYSiwfEFsUlmmsGmzkuS+Fll+4nHkAexytqLworXTGqsIPpG2JxzdvOAK6YQUMcQI6Q==
+"@aws-cdk/aws-logs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.122.0.tgz#aefa41273f309dd0bad91e3541390164e91fd35a"
+  integrity sha512-AKoqNClzvkjcFQYJoYZ9VpjmQfqVtGIJ9pTrOlfWQJV+MI7H2wyK5hiX5gOWDOyd1fqXtGTdrI/fvfIbDo2UQQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-s3-assets" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3-assets" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-rds@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.115.0.tgz#b2724056a162ab98af37ab12696c37cc57700cd7"
-  integrity sha512-pxhMtRqEZqgvgxQdKEk3ybK2A+2AhF9/pgGivvDcs6i0kUrmA9pTvM7SONo8xLrjAOLaiPYbKixtNV04iM9jng==
+"@aws-cdk/aws-rds@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.122.0.tgz#a312d74703b9b6079b602a37af079bfa2eed95fe"
+  integrity sha512-Hdx5BFpRTLljT1afI6rFF6XojDpsOT7Gm/e6MrErGxQyxZ4tgJMBTLpHbbmB8cee2fbVXt1zM35XZxY+EXfPTg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-secretsmanager" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-secretsmanager" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53-targets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.115.0.tgz#7d005113e6a9d878bb76dc05b6dc2b374cbc4a15"
-  integrity sha512-fyqdZcsHAHgYDZNj61y/3ycv5gMfAjNQzyI+DNRRpph9rATfVGCiGiWZm7MGNtYpwbgqEBaalduzM1b934JUXg==
+"@aws-cdk/aws-route53-targets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.122.0.tgz#120128df6344688c692980a967566f03e84e167b"
+  integrity sha512-ZJZ2ogVr1434mSHkNJ9RdN6twMccjziqPr8IsacImJ2WnhYSddzLanvD8dZXJg/Yu4r/Jx6h5Tj0kQcEEG9XPw==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.115.0"
-    "@aws-cdk/aws-cloudfront" "1.115.0"
-    "@aws-cdk/aws-cognito" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-globalaccelerator" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-route53" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudfront" "1.122.0"
+    "@aws-cdk/aws-cognito" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-globalaccelerator" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.115.0.tgz#9b928e8572d6e8bab55665c6da1e807b694ee725"
-  integrity sha512-/K4sNiyTVEwAkPjx8sButuLilbUBD8gatWclrRWHHMO567bcqf+JiZTYRfp0nHJ/DgqBQs9sgPG3BQFG0fJ0MA==
+"@aws-cdk/aws-route53@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.122.0.tgz#388086a679943a95c06210f1d480c08e0e85d2a3"
+  integrity sha512-rGuohz5NyujKGS2pnS78DsFS7ucvcvlzKVnah62LHYdZq9MO6ZfHpa79d1zWaeyOOS3ELD2nopAeLIfE84pEUQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/custom-resources" "1.115.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/custom-resources" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-assets@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.115.0.tgz#f7586b36bb4c2cf86bef73a7f9eb913ff33ea270"
-  integrity sha512-ZD4gSm4TGzCpOZY4s6M+N0ZALDmDKNUoNGnEH7It76UuNtfyZy9gFvms8dOTHOE/mARUM1Ry0SLgs2PTdt7Pog==
+"@aws-cdk/aws-s3-assets@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.122.0.tgz#3e53fa99855932c52ba7a8b11d028579c80e9221"
+  integrity sha512-+Zqt3lK4fXoAUmGFGI5dKGe3ErwOIBrZlejTsXcO7DbrBYXGu2Wxpk3yMgsDkkSyP2uXyEnhxSqCahZOS2vRZQ==
   dependencies:
-    "@aws-cdk/assets" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/assets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-notifications@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.115.0.tgz#d10217478dae74e0457cc558bb86b1a9c27fa5ab"
-  integrity sha512-B0RV85Hcpvo+bUfT2CI7R02eAwpI06zVEQ31aeZofVKnsjuTyp7xoKTAHMRIcXQTrwdD4Wd2h9jarrfAFHLPlQ==
+"@aws-cdk/aws-s3-notifications@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.122.0.tgz#83d5eed49a698e18c5b39533199c2d7ab120ea7a"
+  integrity sha512-euq1ZEr9h+zdGbVN0yQHUPgmV+7Y1Qc0RdmMcIbFQafEFTmvvh1A6EnQb/SqPeNVYRwgv0iNj/7JRsnWbBdvuw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.115.0.tgz#27259ca39ab64584d08995903cee1f2ced4dab1f"
-  integrity sha512-z+lKEhe14dkIBRdCMrtSMOruZezFWfAOrRxQ9eX4zxMhDmsjjlw5c1opLhUVSHldncCvOQg3Y9zlw2XIbLTXKw==
+"@aws-cdk/aws-s3@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.122.0.tgz#d4432c320559aaa8756c4dacc1d7a517c7121af7"
+  integrity sha512-QveBi5KrUusyEc9Ap3998Gs6gUq5H5FQeYAHX+bDIsYgwOWajVStYpzefPfjnAR5TuH8+hXWVFaDzY7BaID4Uw==
   dependencies:
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sam@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.115.0.tgz#4e31561a10dfb4bb71c102938ba1efb874cb6e58"
-  integrity sha512-L4LezqucwBz7J4BZi4uF2e5HgUjNIAxH15ySaoT0EmBZNw7nrx+/jYlWJM0r6iw8Vyj6o7QYhAzNBr5UKdAndA==
+"@aws-cdk/aws-sam@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.122.0.tgz#9c0d79572fad71c1ebcad6c34031247630888c67"
+  integrity sha512-POuc49ctbNHMnbEdA7vR2h2e+tWasmmYtl2vBYlGqMRNXsBm+o6LvE9+x7/kAcJArGbVB9U42FebcdQN8kAdew==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-secretsmanager@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.115.0.tgz#20376c588a5b0b35336b834b713241b7ea29ba14"
-  integrity sha512-2KcS+Y2mmuWKzJZ39cyo/HIqUhsbl82IAmy+9oZUoJyzKzRCOUOpuQBKYJb8QbdLAFzlxewCFpczu4XcSrUcuA==
+"@aws-cdk/aws-secretsmanager@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.122.0.tgz#077a43422811af6800ff3a5d10ece472b6f32493"
+  integrity sha512-wsmsD4z+SSrljj0u3Nk9/xLzcRusCTxGO4JrlC4gTn5YwIhSqDbsxOauSLRHnM+/tOE6C+t5vOfFd3ZrV2YH9Q==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-sam" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sam" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-servicediscovery@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.115.0.tgz#c957b86375dc23a73c1efadc8b06aa943514c04b"
-  integrity sha512-wQ8IzgqEddf/gtEP8NfWHa6ZRfDefugNMtdgqndS14eQxho1VGgsQKw+rp6kBwyHWfUlEs+1akd6TH9SLGyUaQ==
+"@aws-cdk/aws-servicediscovery@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.122.0.tgz#267f95f7c874c6ea9cb8093889c0c1eb20d75ab1"
+  integrity sha512-YjdlJS4tEOqdh0h6RpJl065WZZvL0rj1Qp/pDK32bS4SFmpk5YFFwpcIX84zbJXodn9Hhbowyd3Wzm5ZQMr2MQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-route53" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-route53" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-signer@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.115.0.tgz#6964577f8a413c875259597e0a02ee064c4166a6"
-  integrity sha512-xcdu7vFt+hFWyQueFsyR0Kyc+tHTfYhYEMegHo1LU+DWF3TRSbqK22CcYEhMmoKdcezhGu6WD97zjHCnik84TA==
+"@aws-cdk/aws-signer@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.122.0.tgz#9a2b6611407f72ca5101bc2ee0294b8b076da418"
+  integrity sha512-6J59KrTKtOyH1i3MxQ/9zIfYIocUgGZdqyq9cV7srZ6yUSQp1s3xR+b7LWbBUxs3UMMLXTwchhX/Birc5mXsUg==
   dependencies:
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns-subscriptions@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.115.0.tgz#60612152a5740940e7f025e8456e98b727e96a31"
-  integrity sha512-YIYkOUiwN8QoyDZUWC3zpVOzLFkUvILnRPR3j5ghoNes4bhN85Q8IAZnp6rpFwKFe8WQz41S55f8kD18qMQJQA==
+"@aws-cdk/aws-sns-subscriptions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.122.0.tgz#73a21c71c51b1f85f9846ee7557b03f2d0cdaa88"
+  integrity sha512-kWshuZLSrniXkROAv9TzA3SyTv/hR0Z5uTRIBuHcG5tkR0OaAFomGW3DUfddAI8a4N7rq6u15cSOWPzLVK4EcQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.115.0.tgz#00639cf7f66e08c71f37d3aed038c85cf9951ffe"
-  integrity sha512-bzGx0XafMsin3km6N+h4/JJYhkYPBNrkYzNZ+zMA3l+JlHMIKibEd6nDv+bYupGN7siogEGs4G7WaqUdEwp3Qw==
+"@aws-cdk/aws-sns@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.122.0.tgz#66e15ff3b6ad1866a858109d5c844c122e45fc1e"
+  integrity sha512-nAB4eMJI4tHBsLjsLdPmwhkZkl1M8t9JFv6L1VdH6Y0yxz8V4fVOkPf2btovmVQ/oyniHX+DPkJzmyGw8lnsjQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-codestarnotifications" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/aws-sqs" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codestarnotifications" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sqs@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.115.0.tgz#e90caf284f9870711a4e5312189b008b2ede5c82"
-  integrity sha512-DBNguuqOEMDjwpUp+g8qwbDNdeXRLGfazp++2AxGtdZYLMfovc3YWAAnWpAVAWFltoNS16D3NMKqY7rnknulmg==
+"@aws-cdk/aws-sqs@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.122.0.tgz#03e0c07a80ab33b38ba37b3eb6243f18a5599a91"
+  integrity sha512-ZamVuEfLMj8JpidjqbYR6jiAIvc8yl/WUoDS73nrypWFZf5G9IF7dDPMZ6NXGKnwF6WUD629UpUNgB7grmB4Qg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ssm@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.115.0.tgz#d06f3b79aa08852e6f1b07e559e0b2cfb1833dad"
-  integrity sha512-I8Z1kUQhHK0heMn8wMpkfQfodbmyER69vRLDYo+AlBbvF1ohS+pRA7s9lone3gTMyE956ax5EW1Qv5knVF9Z+A==
+"@aws-cdk/aws-ssm@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.122.0.tgz#31e5707bc818d1166a858db6a5ddd527061006b0"
+  integrity sha512-yoB4tUeV8GgA2MylEMAXlJQUbD9mvOUoZk9zTEGmNyjhpTZBGB24YbBfeoqnq2Igh9PfAlNZkPtguGp/tPZVJQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kms" "1.115.0"
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-stepfunctions@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.115.0.tgz#cc69bf5126f72d6913a73d28b20ae63eeecf4b3a"
-  integrity sha512-Bwd7fAJ/AhlrTp9r3S9PRoepEtC8H7txhyumXts18xCI+nMW3163zOvLTaI5ijx1xIS+eo8V0wRfVEyYz0Ex3w==
+"@aws-cdk/aws-stepfunctions-tasks@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.122.0.tgz#707f6c7944381167192146350232737fa9f50b76"
+  integrity sha512-AFnttLbi9ZcRB/eSJ3DCWBj3v2NoTxlVidkmf0e11ewzJ3ML/PK21kqzhSqBLz2dEkh5U2alee3sXS/8WjObnQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.115.0"
-    "@aws-cdk/aws-events" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-codebuild" "1.122.0"
+    "@aws-cdk/aws-dynamodb" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecr-assets" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-eks" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kms" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/aws-sqs" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cfnspec@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.115.0.tgz#6e56a604650304615657a838aa03d9f17417db92"
-  integrity sha512-5jxzxW35gUyiirUOdJlS9kqRqCJUXmQJnIcpsGGZ7LxIwdkADUjIfZPoBE8lWRoWei1IjD6qe7VOMi6XdlW+mw==
+"@aws-cdk/aws-stepfunctions@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.122.0.tgz#4c1f69446306dbfc0d61b5c33ec8e2a2f97081a8"
+  integrity sha512-X7tAW2gtWRdwoIRPMUIoYnCGDgSyPZK8p3NpvmOX8BDocCTKJQcvp+x58nDHTGU0u9znpePd6hULA1A7OuCy+A==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.122.0"
+    "@aws-cdk/aws-events" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/cfnspec@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.122.0.tgz#c42b76668ba692cea6951e0a29a70399241e4f0e"
+  integrity sha512-41CyWYJLfWfQbJWONNwu1FBIsDfDn3r/0pukc+Bkrsmx2zcPRY/JW+THyFZCyG5x1lO6T4XfGRuF2DfCehLaOQ==
   dependencies:
     md5 "^2.3.0"
 
-"@aws-cdk/cloud-assembly-schema@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.115.0.tgz#a0a7b39360714e57ea68be88d79073765d55315b"
-  integrity sha512-LgrUMdUUyQYfZR1zbDAnx4mYZQSSxNQYeQmBHPoXx7szxWAi9gN+4MajBBz9LrJNf0ZYRu1EQYVaaMa4ScHdXA==
+"@aws-cdk/cloud-assembly-schema@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.122.0.tgz#8e6b86972bc662ac54e152566141a0a4678ee16a"
+  integrity sha512-xyVIaRZbQEoVI8VPbgreK18o0BVVthavn3zUKw6p+S1NF+FMgqatTLU0pq+bMLOHwI/zyNKuZs3KhBoMLyhZMA==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
 
-"@aws-cdk/cloudformation-diff@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.115.0.tgz#3f99a7492e1963dc9cdef9db065dddabb003c724"
-  integrity sha512-1YGkh9SfTUiWUhetiBSGpN3hYlACEZfwpjJ7jpx2AkDjhd4mTydHljOB2vPVBfticPCwDRH+mwiff/fM3VI/LQ==
+"@aws-cdk/cloudformation-diff@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.122.0.tgz#1661bf6adb7421a8702bbd2c71f36d2ea863db54"
+  integrity sha512-syTS6fPd0IASzsOGJUbZtpPzHhW0aTtoPauN4NK7T2ynyEGVMmdW5vikdWBt3Kg5mkTTVvxQix7r1aLiQyMYIw==
   dependencies:
-    "@aws-cdk/cfnspec" "1.115.0"
+    "@aws-cdk/cfnspec" "1.122.0"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -715,46 +771,64 @@
     string-width "^4.2.2"
     table "^6.7.1"
 
-"@aws-cdk/core@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.115.0.tgz#0c9b8d8f14020eaa6296c1fde97fb559153bf5ac"
-  integrity sha512-6agFP+WVqoUyhT2L3osOjrcWh39Ebqnghv/dAsneH5LZwml2vqZFvPDFTkUs9j/Oyv9KSrxO+ge3Ts23+3qgXw==
+"@aws-cdk/core@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.122.0.tgz#726cee4802f49a16c1ec72d320ad33fa67191422"
+  integrity sha512-8yQmOH1e4YvL/MVIDQj2JS1YeijIePshP2fPw7X5iP4tdLcPcHPTXHXJAp2ARF7XL5u03juVENn/hG7G0B91nw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
     "@balena/dockerignore" "^1.0.2"
     constructs "^3.3.69"
     fs-extra "^9.1.0"
     ignore "^5.1.8"
     minimatch "^3.0.4"
 
-"@aws-cdk/custom-resources@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.115.0.tgz#37a9bf99e3b7fbdff5c453628dde4990786b4ac0"
-  integrity sha512-T4VsG9TJ/WeFA/RtlWjADMe6Iuz+iKRJVTeZdkzCwYqcYw8fhKj1TXX73hZ1Q7uK4lqYot0QBK3BUG9WebZESA==
+"@aws-cdk/custom-resources@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.122.0.tgz#e4554dc9b4e3917a4f935ff3884d6bd1ccbca9ed"
+  integrity sha512-vdipr6cpCIYl0lokS0HQI3kY34mqpxns82+MzqYc95xZ7HPYOjnP0aKqL+UKIpaQsTVVUkOqfxZ9cXNdv04Xag==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-logs" "1.115.0"
-    "@aws-cdk/aws-sns" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
+    "@aws-cdk/aws-cloudformation" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-logs" "1.122.0"
+    "@aws-cdk/aws-sns" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
     constructs "^3.3.69"
 
-"@aws-cdk/cx-api@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.115.0.tgz#8ef8d4c4e10c04ef33a69b574db5cda081c00f27"
-  integrity sha512-yXk5szvv9B9PtDZRWAl+yBkxmGg22FFwhJ/YEJcGvvZW6YkWhAaaVKlnJCq5jdIN+wobN+PVN1Tyc/JIcOTzjQ==
+"@aws-cdk/cx-api@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.122.0.tgz#431f3a5a7ec339fdfff0387e85f2e5956a43fb17"
+  integrity sha512-x2SPWc3RNBWi5UBdq/gZvW5He9X5NRb2j9pcBcUPhVSSEB7Fl5lqPU82q8mBy+76zHkfWILpLGJr/jNQ4ZRAeA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
     semver "^7.3.5"
 
-"@aws-cdk/region-info@1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.115.0.tgz#eab265825926bbef3d0a3367f0bbfcbef7ae0a9d"
-  integrity sha512-07Ae/T71wdTYvbii/+J0n4PghD/W8bsutkrpBMgIg/Rl2rfv5ZqZRvCpQ40MkoscS1SnWYSzJ6T79TnNuuJZ1w==
+"@aws-cdk/lambda-layer-awscli@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.122.0.tgz#ec3aedc6bc595e191fd8993f95b2c81cf3ec75b5"
+  integrity sha512-ecWutnWFluWYgAjGORiHUTvCCcD24FPl0b6NqT2Ex5vQmTXHCO4CdHncL0CIwQwNE6zGzQitTKEc3snumGVGng==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/lambda-layer-kubectl@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-kubectl/-/lambda-layer-kubectl-1.122.0.tgz#6e0b21f1843dcb89eaa47087591008e155b26272"
+  integrity sha512-TxZUaAUMCQbTeZPz8PWVOU/b/gMEHOoJ2AONNhYB/vDNHNBPdReBguCh6BLWYtIXlfWBrAJ3kluTmsZFGIGlvA==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/region-info@1.122.0":
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.122.0.tgz#05dc2fe82c365dc6b458a5e1138faa833c578e19"
+  integrity sha512-6nFk66RE+PYh85aU07tA3TxsfKUHZZxnPITidwnyJYZ2OgimxMRIuWQce1bSLkZrcaQhachcJTJ1o8mF20kJmg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1268,31 +1342,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@23.3.0":
-  version "23.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-23.3.0.tgz#c0fbd1d05e2b792115e5f7aeae419078ccfb427f"
-  integrity sha512-r0qDOwzOxsMDXYJp100266Zy26U5Dt1vYo+ivBhokyu/hgPrcWcVApBcEWaGQGw0FBwnlGJnQ+cGLcD5SsX+Eg==
+"@guardian/cdk@26.2.1":
+  version "26.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-26.2.1.tgz#e597a973b219401f17357666ba68d9198fa89ecf"
+  integrity sha512-AKSPhJURsBzBoFsCgOra8yWGltCqtYV9qcJIusQ+UiZsB+yOfD0u4TKZ7sUg5yNv9NEUMwj25CtY9/u+hmsT1w==
   dependencies:
-    "@aws-cdk/assert" "1.115.0"
-    "@aws-cdk/aws-apigateway" "1.115.0"
-    "@aws-cdk/aws-autoscaling" "1.115.0"
-    "@aws-cdk/aws-cloudwatch-actions" "1.115.0"
-    "@aws-cdk/aws-ec2" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.115.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.115.0"
-    "@aws-cdk/aws-events-targets" "1.115.0"
-    "@aws-cdk/aws-iam" "1.115.0"
-    "@aws-cdk/aws-kinesis" "1.115.0"
-    "@aws-cdk/aws-lambda" "1.115.0"
-    "@aws-cdk/aws-lambda-event-sources" "1.115.0"
-    "@aws-cdk/aws-rds" "1.115.0"
-    "@aws-cdk/aws-s3" "1.115.0"
-    "@aws-cdk/core" "1.115.0"
-    aws-sdk "^2.960.0"
+    "@aws-cdk/assert" "1.122.0"
+    "@aws-cdk/aws-apigateway" "1.122.0"
+    "@aws-cdk/aws-autoscaling" "1.122.0"
+    "@aws-cdk/aws-cloudwatch-actions" "1.122.0"
+    "@aws-cdk/aws-ec2" "1.122.0"
+    "@aws-cdk/aws-ecr" "1.122.0"
+    "@aws-cdk/aws-ecs" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.122.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.122.0"
+    "@aws-cdk/aws-events-targets" "1.122.0"
+    "@aws-cdk/aws-iam" "1.122.0"
+    "@aws-cdk/aws-kinesis" "1.122.0"
+    "@aws-cdk/aws-lambda" "1.122.0"
+    "@aws-cdk/aws-lambda-event-sources" "1.122.0"
+    "@aws-cdk/aws-rds" "1.122.0"
+    "@aws-cdk/aws-s3" "1.122.0"
+    "@aws-cdk/aws-stepfunctions" "1.122.0"
+    "@aws-cdk/aws-stepfunctions-tasks" "1.122.0"
+    "@aws-cdk/core" "1.122.0"
+    aws-sdk "^2.996.0"
+    chalk "^4.1.2"
     execa "^5.1.1"
-    git-url-parse "^11.5.0"
+    git-url-parse "^11.6.0"
     read-pkg-up "7.0.1"
-    yargs "^17.0.1"
+    yargs "^17.2.1"
 
 "@guardian/eslint-config-typescript@^0.6.0":
   version "0.6.0"
@@ -1526,6 +1605,14 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@jsii/check-node@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.33.0.tgz#55d75cbef1c84e2012c67ab8d6de63f773be4a9b"
+  integrity sha512-Bajxa09dhkuQ8bM1ve6qtm2oFNhW9/+GaKRh4Deewsk/G86ovLXI/rRS6TfCsSw4E0TGPFWzWy0tBeJuEDo7sw==
+  dependencies:
+    chalk "^4.1.2"
+    semver "^7.3.5"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -1991,19 +2078,20 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk@1.115.0:
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.115.0.tgz#eb066fb4a5bf7c5e20b7eedb08d4dfdcf2722d75"
-  integrity sha512-9AQ/m51+6NmS3WxuzW22+u0Y3kg3GtZIdugE0mYMzq0J30Z/IowEf4e4YUNVA9IDA28le4oenDSVMrdj5WPG1A==
+aws-cdk@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.122.0.tgz#2efa6d1b7c1474344b6c68dff52aa056591a70f9"
+  integrity sha512-AdWTa0Oxkcz51Cm6sdYwtTB0NQ32j8UW34W2C9Z2G5G8SMUSJd4tH+RS+XEHNaYyYLGaP+Gpvajt+cDviOIBjA==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/cloudformation-diff" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
-    "@aws-cdk/region-info" "1.115.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cloudformation-diff" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
+    "@aws-cdk/region-info" "1.122.0"
+    "@jsii/check-node" "1.33.0"
     archiver "^5.3.0"
-    aws-sdk "^2.848.0"
+    aws-sdk "^2.979.0"
     camelcase "^6.2.0"
-    cdk-assets "1.115.0"
+    cdk-assets "1.122.0"
     colors "^1.4.0"
     decamelize "^5.0.0"
     fs-extra "^9.1.0"
@@ -2020,10 +2108,25 @@ aws-cdk@1.115.0:
     yaml "1.10.2"
     yargs "^16.2.0"
 
-aws-sdk@^2.848.0, aws-sdk@^2.960.0:
+aws-sdk@^2.848.0:
   version "2.965.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.965.0.tgz#e63fb38bcc77334a3c9edbe9353050312f3bdbfe"
   integrity sha512-jifeFsA6IEKXM65WI5gvBNSCXKw4n64Wf9Q7/8E7wZ5vzRbBGoHzGpyhK6ZBBRvE2YvNp/ykTWChO7RydkA+AQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.979.0, aws-sdk@^2.996.0:
+  version "2.1001.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1001.0.tgz#c4da256aa0058438ba611ae06fa850f4f7d63abc"
+  integrity sha512-DpmslPU8myCaaRUwMzB/SqAMtD2zQckxYwq3CguIv8BI+JHxDLeTdPCLfA5jffQ8k6dcvISOuiqdpwCZucU0BA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2228,13 +2331,13 @@ caniuse-lite@^1.0.30001219:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz#fe17d9919f87124d6bb416ef7b325356d69dc76c"
   integrity sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==
 
-cdk-assets@1.115.0:
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.115.0.tgz#4e544283ffb2c31cde54cd4de7e82ad23350908f"
-  integrity sha512-DaVB/KF6JAuWdUQX7IwNSk0Z06wN00q1lY90DeWFsD6xv/rF7+iD2B+eywxo5fJD6/Jt2uTX9OrftDr65SYrqg==
+cdk-assets@1.122.0:
+  version "1.122.0"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.122.0.tgz#dd5f58b11499021a72cb16c16b0c01be4be0bc12"
+  integrity sha512-AbJgrROkwj0hmFLcCtqxJLTAVqFyMP+rIS9XM9nfrEIgoNzJnmy1KgJneuXNA9U7dquSFlTPYfAoy2UCTrryBw==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.115.0"
-    "@aws-cdk/cx-api" "1.115.0"
+    "@aws-cdk/cloud-assembly-schema" "1.122.0"
+    "@aws-cdk/cx-api" "1.122.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.1.7"
@@ -2254,6 +2357,14 @@ chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -3158,10 +3269,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
-  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
+git-url-parse@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
 
@@ -5789,10 +5900,10 @@ yargs@^16.0.3, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
-  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
+yargs@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
## What does this change?
This change updates @guardian/cdk dependency to 26.2.1 with requisite changes to keep everything working correctly.

## How to test
run /script/test and fix any errors
Deploy to CODE

## How can we measure success?
keeping things up-to-date

## Have we considered potential risks?
this change mitigates risks of cdk version becoming too far out of date. Main risk is that there is some unknown change in the latest versions of cdk which we havent captured in our testing, the greater risk is not to update though.


