### PR TITLE
Update CDK to 41.1.0

### DIFF
--- a/cdk/bin/amiable.ts
+++ b/cdk/bin/amiable.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import { App } from "@aws-cdk/core";
+import { App } from "aws-cdk-lib";
 import { Amiable } from "../lib/amiable/amiable";
 
 const app = new App();

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,7 +1,6 @@
 {
   "app": "npx ts-node bin/amiable.ts",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true"
   }

--- a/cdk/lib/amiable/amiable.test.ts
+++ b/cdk/lib/amiable/amiable.test.ts
@@ -1,6 +1,6 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert";
-import { App } from "@aws-cdk/core";
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
 import { Amiable } from "./amiable";
 
 describe("The Amiable stack", () => {
@@ -14,6 +14,6 @@ describe("The Amiable stack", () => {
       domainName: "amiable.code.dev-gutools.co.uk",
     });
 
-    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 });

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,7 +22,6 @@
     "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0",
     "@types/jest": "^27.0.2",
     "@types/node": "16.10.3",
-    "aws-cdk": "1.152.0",
     "eslint": "^7.32.0",
     "jest": "^27.3.1",
     "jest-teamcity-reporter": "^0.9.0",
@@ -32,13 +31,10 @@
     "typescript": "~4.4.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "1.152.0",
-    "@aws-cdk/aws-ec2": "1.152.0",
-    "@aws-cdk/aws-elasticloadbalancingv2": "1.152.0",
-    "@aws-cdk/aws-iam": "1.152.0",
-    "@aws-cdk/aws-rds": "1.152.0",
-    "@aws-cdk/core": "1.152.0",
-    "@guardian/cdk": "40.0.1",
+    "aws-cdk": "2.20.0",
+    "aws-cdk-lib": "2.20.0",
+    "constructs": "10.0.110",
+    "@guardian/cdk": "41.1.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -12,760 +12,6 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
-"@aws-cdk/assets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.152.0.tgz#a90df458b90dc236da481959fcfa243c49132785"
-  integrity sha512-PEsrKaQqf0NIik7RlIoXdbJj8KATAV4w5tLZxr1HTaUdRaPYp2U3caaU3dsqZl2Tq+/EqPbvU87vP7H4qZ28iQ==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-acmpca@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-acmpca/-/aws-acmpca-1.152.0.tgz#7d84a6f6fe883bcadc58a85669770814555000a3"
-  integrity sha512-ZQKQSBF0T2Bs9JOVR4VIUDx+hqVeC/L1+guyeqCaMbqenNeA2hKw0JrqAPd6NSxwSXSr/kpi4shOjeR1MpEMjw==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-apigateway@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.152.0.tgz#16743929841ba2b08cae51dd8dfdebec87a7f733"
-  integrity sha512-ZYG13EtH0+cbBp+NbHvAF2RGUP4HG5f5/VW3JJ6iZcm2+jpRcjgFedRWFGGpUwm3fF86y1CjJ/3VtvfM66Bb0g==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-cognito" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-stepfunctions" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-applicationautoscaling@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.152.0.tgz#4e055ba9594f09dff98ed139be0094b9b3067c31"
-  integrity sha512-u+dCWyE6pLCFc7h3DmUJf7C8+JAcbl65XG56vIxl3meQayJ01SMt2eaEFX9/I6f93V46N41lk0Hgmi+CX5SG8Q==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-common@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.152.0.tgz#ea864cac8023f656498a43a63cac9e92ee46c8c2"
-  integrity sha512-19l82uZC2DhoTBJdT8vR9XoO9U8lmOs3X4xFpdA7Sp+3nVEvly0Hkk2L0SZdhBuXfdlxjZ+nxdlsmAS8jzXLGg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-hooktargets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.152.0.tgz#6ced602c63ce486fb06d660203c1400091ebe598"
-  integrity sha512-e74rRhIkbaOVrLQ76GgLXaLB3ky8I1+5LhjFpXRcZ6oaRcFRhlWsBnFj4XVm4vV11P9wdUNQkCdGfBxg5Bu6KQ==
-  dependencies:
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.152.0.tgz#41cb6f7c135bbbcc9c24f9d0420b8a7acb660ee1"
-  integrity sha512-TO2IiAWruVpx6gdjxUGtorYBt6gr+b7n0AIGH4ECbDz1kfOi5OAS6DVDeKlC+sOBLsvc4aSOIdfGHtN8bZvcVA==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-certificatemanager@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.152.0.tgz#f62de1c41426d447fccfc57f97cba4ad491e16ec"
-  integrity sha512-YnW9kv4o3WmGsU1YYQ6eCUO3M4QLjQumDhVkEucxTRGIDXQUcBhUZ3yKQaKQ3i1bPGaILTffcg7oeeM7n5/Fmw==
-  dependencies:
-    "@aws-cdk/aws-acmpca" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-route53" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudformation@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.152.0.tgz#fe95faaa47094aef0b566c9bfaab8b5dcf68221d"
-  integrity sha512-jxsbHIBw1WMIJYHW09i9/8wB7P6DrR3Wlb2R255/c3uOZafz12xICKMeolZLDLQ7wPxCNayauWiXURmZLT8G8g==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudfront@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.152.0.tgz#95ee59dc45010a8b8671501f4753c0dade95c8db"
-  integrity sha512-9tBIRfIvtf58DSB54dDleWC5RkJhC6A9l/t6uzOuprpgklYR0iLmKjqAB08L99RBvvfsdQhwdbcP7ISEmtGUrA==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-ssm" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudwatch-actions@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.152.0.tgz#c9695fced5737bb0c3119c8ca38bc9a858ee90be"
-  integrity sha512-8IWQp2fv2lZqTv7XgZX/ZL415y7UgPTtGk1i3VfUA7eEqrb81NKguTAQ+mIprQKvuQLKCNQOKyJn5Bv4nVeOsQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.152.0"
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudwatch@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.152.0.tgz#22c12ff1d8bfce9c4807b6ddb91b94e51120b2d6"
-  integrity sha512-qMKN2QPV1749/Lhj2cbhFyVoRmRxb6fmNzl/2R6hc62RCEUNHQzfIn0iz78sy1WCl0MaQWun+PBIL13S9hsssw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codebuild@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.152.0.tgz#fb1cba1cd23f6afb32f8d5a48b08021925ee513d"
-  integrity sha512-RTkbLUzvA+SDzG3zfK+OqlNliFU+vuwkjjFxjh2Nq1IIm/hzEC9HEps9JB2eSFCArpib8dHpCimALKlEOnNDUw==
-  dependencies:
-    "@aws-cdk/assets" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-codecommit" "1.152.0"
-    "@aws-cdk/aws-codestarnotifications" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-ecr-assets" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-secretsmanager" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-    yaml "1.10.2"
-
-"@aws-cdk/aws-codecommit@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.152.0.tgz#56006adfb193ef4ba0669a7c9e760da55fe0a8c2"
-  integrity sha512-CEkFPDdCLb6kTHRktDdYutTaEYDx5eSNXBu89g32AOFNdtCryZqCPHIZRnjes99wNR8y+79r7zNj5gVOqbPxgw==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codeguruprofiler@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.152.0.tgz#080c038fd796e8ef2bc95d80d3b0c3520a1b8a10"
-  integrity sha512-S1it9kv/1yS7MCUI7R+5dqxdd7fEFhkBG7DdSQAkLiRFY1sZ4BmPjPP266LfekPWeDMZlPAgtoz1e7P1oDkvUQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codepipeline@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.152.0.tgz#7a1f42eab878b3d386fc787a6899e167f2df5514"
-  integrity sha512-VODe4EpS0yhpjQBrvOnhgQB27vwZglW5UAnHUFZ/+QOz8cfjZJdpJ3c/9XgTq8f+/AOoTql8YZzEoYqq2B8jFw==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codestarnotifications@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.152.0.tgz#85bcb4f95292f720f1e43a9b8dce77523470c82e"
-  integrity sha512-Xkz8NaMhGkF6ZZ3MFM4xUARubKt0h7jk0+DftadzVzH+1EBJYbi+6g9Hnfkhd1/mMQMXXg3fnlQL/Z6YC80xRw==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cognito@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.152.0.tgz#cc3e1fff85876c1b6f2e8266e10816941bc64b44"
-  integrity sha512-aVxUXmonew0L36cYBdAv1oIZDr1gmstEcVg6eezt2ovsg5Wpn7cA6JI2YqcNvsccHs2mIOpS3p7MH6IIQrvvnQ==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    constructs "^3.3.69"
-    punycode "^2.1.1"
-
-"@aws-cdk/aws-dynamodb@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.152.0.tgz#e305b830260af3cbe4a6dc0af6334aa860dab27a"
-  integrity sha512-qh9VBW58L/zd2WvZ587YqfK9bKNE/E1qEsxMrfOaMEW12HssbgfQgjRQbtUP+ducu1S98O5++qI1/N3LFaNlzw==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kinesis" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ec2@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.152.0.tgz#0bef1dc1a4d051b5f4d0a9563f08712689007f81"
-  integrity sha512-8hv55cFpo73r17gacfFMde+C/OpzkUE0K3Pn0hiSUkPh9mkm3BSHV5IBGOa6ZQiMovE/bQtDvYA/W1W5nJsJpw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-ssm" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecr-assets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.152.0.tgz#2119b5f6eb498e71930852acaad9af2e816a9a26"
-  integrity sha512-jVwB+Z+JFeM2NuHefqeZwovO/vawtVQBiexFoTainEglKFuX+xI9swpYbRJfoRaFBY7/X1TeKgci8orLFphxmQ==
-  dependencies:
-    "@aws-cdk/assets" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecr@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.152.0.tgz#e79afc339592a562a14acb736a6688fe90c7d220"
-  integrity sha512-c95MF+I44zFX4n6SeuJNUKHqws2nXAQQrxuDo/xQxuKyuqMl2zE9+wTCTr5vXNabplkDBckFxNkA4QZyN47QEw==
-  dependencies:
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecs@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.152.0.tgz#a34fdd786d04a2c67da411df7908189e39595e6c"
-  integrity sha512-C7aHrIj4XMwFbI1WGHENVKNDp290O7/JFwmthzEKEB/FiPE1UrKEsr0AVlX9o9/PVCrRCZH1WnmqcmO9X2uIdA==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.152.0"
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.152.0"
-    "@aws-cdk/aws-certificatemanager" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-ecr-assets" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-route53" "1.152.0"
-    "@aws-cdk/aws-route53-targets" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-secretsmanager" "1.152.0"
-    "@aws-cdk/aws-servicediscovery" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/aws-ssm" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-efs@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.152.0.tgz#f597af0a51d75944773bce7aaba55f841d8cdfcb"
-  integrity sha512-CuacyJXttDM85gTfdRkIm/r+Jg1covSLQkSWktbdV/Tqr+C5DuYKDoLN5d4sFJIX0pNSVV5czr3XSoSlQJ/gHw==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-eks@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-eks/-/aws-eks-1.152.0.tgz#67153732941c7dca06cb7f6cfdbea0dd64ae10cb"
-  integrity sha512-djIPbiG1jZsf0Mx97LlWQf4+LJ5aejBo77llgmJj94W4iYeSgxbH+1wIKAp7t81LEMZM4bp4JoUy20VkIq6DpQ==
-  dependencies:
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-ssm" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    "@aws-cdk/lambda-layer-awscli" "1.152.0"
-    "@aws-cdk/lambda-layer-kubectl" "1.152.0"
-    "@aws-cdk/lambda-layer-node-proxy-agent" "1.152.0"
-    constructs "^3.3.69"
-    yaml "1.10.2"
-
-"@aws-cdk/aws-elasticloadbalancing@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.152.0.tgz#c942c33c88eec770a5b20023f6572e8670bdeb97"
-  integrity sha512-stevB7UEfP3CaS79qJtq8BJW8HZocF9eovf12vDGb7t6kkxIb7Ar/4ClLXO0TLPfh2ewGbaO9Jjdkq44N9UxAg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticloadbalancingv2@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.152.0.tgz#417779105821d0a724afe6eaedd3d62012419dfb"
-  integrity sha512-deSJUGZmrmoc7avcInGfFTnoj60yVj+wYmAjE6AgeE9WV6VM74QMSzSoQfX6ZkBDvBLTA4hVFa2BBmuyJbzz0g==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events-targets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.152.0.tgz#b93a4af7c5fd995e6fc220eb66940aa2245bed44"
-  integrity sha512-J/tw0bgLe49dDOjFZvL0ak6bm5+RnxafvnarG2WanP7IzWkmo4CZrxtSjZ5KTNSvLmSz4ARyYlLcY+IBd0h1UA==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.152.0"
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-codebuild" "1.152.0"
-    "@aws-cdk/aws-codepipeline" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecs" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kinesis" "1.152.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/aws-stepfunctions" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.152.0.tgz#105c8eb8e7f964b570dc88017af648d14a535c58"
-  integrity sha512-gGbsrKVkLrn+OcC/bx/C/BOKMRc+AtX6cvuvr2Bt6B3PrgXCje7fCsK4+IFDBcZOS5OUjXyGwp+MKUFMUVHSBQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-globalaccelerator@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.152.0.tgz#b3d99e90e76829bcebe534c29e30edf395f0b091"
-  integrity sha512-5bH688nx4sGoDpzxWRGjJ5Cm9hNVqg5Svms5zfi1VJmlvofcLYh2jwVrMp4ApMVaHjwUNcq+5D+0LCPf5/CRUg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-iam@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.152.0.tgz#a82461794148ce36f630f391fa89dfea8a208744"
-  integrity sha512-Nwi3DAhWyJE1SDnhYeutio/RnjzfrM5UguSLEeHDg8/r5pIg6297V7y4YhEgqNM3+CRLDu8KyuBXRxZp4ZixpQ==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesis@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.152.0.tgz#bd6147af8b20b31c1315c2d7e5a64dea4b4f6a26"
-  integrity sha512-7r1vFQMEUwjnWgBRy5qzn5fIgEsAI9i4CowRCj5B2TosI/vvMVpCMoB2qtyXSrsgLqr7TSz+Bq6lP1Nec1DeFQ==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesisfirehose@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.152.0.tgz#ece26d9603aa80a84d50fd41ba40f449eb3c44df"
-  integrity sha512-5tT3WzvA9ER8CoF65mnSeaFP+ycKpqVqzEAjXRs1P1CLeIDYMhbWzca62V9VKC5cN0ickdq69Y96fMJk30UllA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kinesis" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kms@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.152.0.tgz#28be3f98cee36cd1a3550b68831b2eeec171b8c6"
-  integrity sha512-+nj0o2heN70JdHfXnrEE2Kne8XB2FbwJw7XXxNesgcOGnlpP2vVBB9KrGs8QQe4JoC++5enktqwzpSkZNPtwxw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-lambda-event-sources@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.152.0.tgz#b07020328d0d9e1ba4d8ed49dd4b60ecace2ce66"
-  integrity sha512-8JZsQ5o0OBsmCr43VvFfm1zUvQ9/8TFmCeFW7mHG6ugvHR5m4aWW+XOl+eKk3TuTjQVjX9a2kxKJe8yhD3uY6g==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.152.0"
-    "@aws-cdk/aws-dynamodb" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kinesis" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-notifications" "1.152.0"
-    "@aws-cdk/aws-secretsmanager" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-lambda@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.152.0.tgz#2a2a2ac964f18d0a68e9e5a986f4549d65aa8204"
-  integrity sha512-scwA2pSYuSEpJSzcfCfkgRtMnlfXMfVbwIE28oKAq5y8kIYUg1GXSGICqL0cxAZjB8HBqiW3nI5o27gbfs0thQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-ecr-assets" "1.152.0"
-    "@aws-cdk/aws-efs" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/aws-signer" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-logs@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.152.0.tgz#31c280b5b67ebfe91b016628587260ba13489bce"
-  integrity sha512-UhNdaDxHeVtrNelRbt+e+ZBJHfzdiVWku4e9TpfN3/tiCm9YNmwaY71NyeExMwdCFqIFwDhzv1GEeoghU+5k+Q==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-s3-assets" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-rds@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.152.0.tgz#ce2fc500311e31afd1304064b593ff1ec5ae286c"
-  integrity sha512-UOx/Cpy4U3wZDJDEC+DLWqtEyziAcFERz9L8cPdF49m+09O8f8vVGdEEamdKhX7Bi2r7Ojbf9OEw9/lpEqVoqg==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-secretsmanager" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53-targets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.152.0.tgz#c28f714b3434e475ee50d40a02b947dd91d12d71"
-  integrity sha512-hJWR9V0C+8gTHCgGHxPbzdOM4Y1ym7rPuhOMpg8x0HVoVWkBHIC5uYAaYdtdW7/IrrIZuRZI8dFPC7YSXIeAfQ==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.152.0"
-    "@aws-cdk/aws-cloudfront" "1.152.0"
-    "@aws-cdk/aws-cognito" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-globalaccelerator" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-route53" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/region-info" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.152.0.tgz#edf4463ee5858908e1da4553acf889940d89d9e8"
-  integrity sha512-GrIPpcT+S881n/HRpwk2rjVScKFDZP4bdJtxXkHEpeQoXtU8TBQkRDIJYa7afLNNCXz9PcF//Ng9EkC5nxjTzQ==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-assets@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.152.0.tgz#c0e0c760322c9cbbe7449b2ecffae66fdb267cf0"
-  integrity sha512-W5dt0ZniWJEA+7KXsGqttlmVfTZznsS8cJFesBN/TesQUq1MR/v7D/CgoetZWNdZJtZ6DJuqD2NBS2g7bcLFOA==
-  dependencies:
-    "@aws-cdk/assets" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-notifications@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.152.0.tgz#9a33a20c2a760eabacda01d9fe79b7d5a4e95f7c"
-  integrity sha512-mFpwvTVSKY3kvRBT01IBGE7rXxFVp98D+5slS16ydqnUqJMkw8YdqSTH+hB987FTwVrtXLMP+bcqjfkdiTEv3Q==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.152.0.tgz#fd4a830f638dd9af2237c1a18555a5f181d2c5b5"
-  integrity sha512-3a6uGMdZ41OWTDXo4b3rM9FUCBKEUVBt/kgm07GZq2kBj13/d6O7DBWp1bUq0fYIjftk2AAXkXOwsORuPMgiPw==
-  dependencies:
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sam@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.152.0.tgz#af3f9c50dbea65ac0a9f2bfd5c3149e8b82faa6d"
-  integrity sha512-4dSNoNHQO+HmcEn9SCxKJRqzXeNWnlIraPtqMsT4r/qE9VxlXzxz2q+5cyEEnSiPNTEvaR8GhfLae4ySvIbjNg==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-secretsmanager@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.152.0.tgz#d828f888cdb8634ddfb65ea5672f8c83d5094631"
-  integrity sha512-he6+0wGIoe6Z2I//16sZkK/pMVK5AlIGgE1SCyKxL4eS3MR2fTDMLqj3xuBzOucFZ7yvDdHntw0f795DUJr7Uw==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-sam" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/cx-api" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-servicediscovery@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.152.0.tgz#dd35930ab7fbba61cd41016cf07f3934d5af33c8"
-  integrity sha512-3vnCIDMGrPlUs0CHG7dNTolNLbcoSSZArw2lbnKv41cEeGXEcRNnbutoGn3V2Pqm6xNLM5O0mA+pZVg8inhoPQ==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-route53" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-signer@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.152.0.tgz#6404b711bd27497d81dfd2da3a52f96247a29b1c"
-  integrity sha512-DB1BogYuba4T4jcPfgddvOATILSUU+3t4w41v9j6ILihG0MHRl3LxhXnTRXO4WTuRHUdIgzf7CnhCHZlC4JvDg==
-  dependencies:
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns-subscriptions@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.152.0.tgz#f9a9223d8c2115a86e46bbbb5b3398aa33bd58cb"
-  integrity sha512-YpqoXkboAW3O6HgKpEhmz2rclAB+x0xlMgX8d2vEo9+lGNho6eVUt5N5TlUFX19Z6/LCPDQA+W9qwuzB26SMBQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.152.0.tgz#5ee1125077681d486a36a0d6745f9b12e3f6e09d"
-  integrity sha512-vmKyR1NdRBAbzmzq1jBCnjGmF3FhSjAuQMfHNDxNdjTSAh2gtBWG2I4BHfjOFe4htQDWAkGxTqHnXSr0lxHdaw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-codestarnotifications" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sqs@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.152.0.tgz#6f526cc42725109390d737717849fe7f9b9c1c4b"
-  integrity sha512-3iywkWepUrrgKCAUR2HbGVNRoHVZXCd+Ap9um2PU03Z//5xW4cnoXADmgD4QR5TXVSycMSfQqHTY/QuoaCZ8wg==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ssm@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.152.0.tgz#ddea1ec97b9a9f5078078dda42ab20ce75208f2b"
-  integrity sha512-sXmdGtkFJKR+Ny0iG6HNUHPFI63yOb1wWb5qtVhbM25C73H571OQ2rItUwfgfJCoJbJQSyLPkbwLUvEemzz/ig==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/cloud-assembly-schema" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-stepfunctions-tasks@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.152.0.tgz#d12abc76d953a4e04307a28e5ee727a2f2fdb3b5"
-  integrity sha512-C5uelwJz4zUgEXI3sOcLqMahWk4PUkQuefiHJd5ycwpa+6hOrHliF/X1bT5FJLb+pyMlRAMbh3LKSJmmMND6fQ==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.152.0"
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-codebuild" "1.152.0"
-    "@aws-cdk/aws-dynamodb" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-ecr-assets" "1.152.0"
-    "@aws-cdk/aws-ecs" "1.152.0"
-    "@aws-cdk/aws-eks" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kms" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/aws-sqs" "1.152.0"
-    "@aws-cdk/aws-stepfunctions" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    "@aws-cdk/custom-resources" "1.152.0"
-    "@aws-cdk/lambda-layer-awscli" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-stepfunctions@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.152.0.tgz#db1a6180b9c2bf2cf285cf2432d80d56099c19e7"
-  integrity sha512-GsPeER6XTgEhlQzaBkX/rWRnpHkochG5N/MwXz12L9V5J3wxKFkWbY2yD1hF32gCIdRW4eZ0HyRmXN3BCsX4KA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.152.0"
-    "@aws-cdk/aws-events" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
 "@aws-cdk/cfnspec@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.152.0.tgz#c2939df10c6675aed332eacca5020392b0ad6e7a"
@@ -809,20 +55,6 @@
     ignore "^5.2.0"
     minimatch "^3.1.2"
 
-"@aws-cdk/custom-resources@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.152.0.tgz#f8ea849f4c6d27d84d5b76ca44d2ae0d12a08beb"
-  integrity sha512-JjDhgJQQzcyIkeC46FEp1T5wyJhfW9Kzkw9/Nj74ILkWjhdLG7zDLtECnSwr4G/F0nt5+71Ddrj5J/Ej+KwsUA==
-  dependencies:
-    "@aws-cdk/aws-cloudformation" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-logs" "1.152.0"
-    "@aws-cdk/aws-sns" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
 "@aws-cdk/cx-api@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.152.0.tgz#0571c1dba1f55c0ac063b74dd764e04cb8bd035f"
@@ -830,33 +62,6 @@
   dependencies:
     "@aws-cdk/cloud-assembly-schema" "1.152.0"
     semver "^7.3.5"
-
-"@aws-cdk/lambda-layer-awscli@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.152.0.tgz#bb2d836345c0216e7a7afdce9ad121cb1b67ef5f"
-  integrity sha512-1ek52jalCDoXgdfbUFCDmqV9t7ndOeN7AE6IZZJSbcq91Nl3/Hfxex/ktc73nCOjOC0xBJDKxmzz1iTM2eO2mQ==
-  dependencies:
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/lambda-layer-kubectl@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-kubectl/-/lambda-layer-kubectl-1.152.0.tgz#1c1fa95dc7e0b25c4f2072c20f3655bdba9d9737"
-  integrity sha512-xjuhEydw+b2sWHMjWXJmftiD57wIQmDTsi9RVy4EjjpX7gFti14R2bxAR4iWDjB/RngZqezJfQQ2Y6LLqOVxmg==
-  dependencies:
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/lambda-layer-node-proxy-agent@1.152.0":
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-node-proxy-agent/-/lambda-layer-node-proxy-agent-1.152.0.tgz#bdaee1299c25385d3d583558936f574459736b52"
-  integrity sha512-fGbcyBBU4O4d7Q9KhDAhbPlM7mLQXionxkqzMeUvOTqx0WOC/runo/DAN3Z/4TnXA1KI2J2Ywlh1r0jRm14N1Q==
-  dependencies:
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    constructs "^3.3.69"
 
 "@aws-cdk/region-info@1.152.0":
   version "1.152.0"
@@ -1375,34 +580,17 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@40.0.1":
-  version "40.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-40.0.1.tgz#48fd9b926b497d65e56fd2f8b7f1cf58ff10422f"
-  integrity sha512-IaYHd8xBVv/ed7oMmYu8xXO7dnuiy8S1HKnW2rcGCRhn6i+vv6TI9Zkk5w/mV5Ftc6gNY50Lo8FilOMEv9LKSg==
+"@guardian/cdk@41.1.0":
+  version "41.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-41.1.0.tgz#b070bb7a8ffa111b7f024b3a5bd8232d5a564192"
+  integrity sha512-/RCQLCKf+DFle2BVhtbbXbef8+XmsgRl1V8RAAMjCdkAKfk4YAoMoBg/Z9xLKr+HKdMDfsSJowLZZ6gwswKpwg==
   dependencies:
-    "@aws-cdk/assert" "1.152.0"
-    "@aws-cdk/aws-apigateway" "1.152.0"
-    "@aws-cdk/aws-autoscaling" "1.152.0"
-    "@aws-cdk/aws-cloudwatch-actions" "1.152.0"
-    "@aws-cdk/aws-ec2" "1.152.0"
-    "@aws-cdk/aws-ecr" "1.152.0"
-    "@aws-cdk/aws-ecs" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
-    "@aws-cdk/aws-events-targets" "1.152.0"
-    "@aws-cdk/aws-iam" "1.152.0"
-    "@aws-cdk/aws-kinesis" "1.152.0"
-    "@aws-cdk/aws-lambda" "1.152.0"
-    "@aws-cdk/aws-lambda-event-sources" "1.152.0"
-    "@aws-cdk/aws-rds" "1.152.0"
-    "@aws-cdk/aws-s3" "1.152.0"
-    "@aws-cdk/aws-stepfunctions" "1.152.0"
-    "@aws-cdk/aws-stepfunctions-tasks" "1.152.0"
-    "@aws-cdk/core" "1.152.0"
-    aws-sdk "^2.1109.0"
+    "@oclif/core" "1.7.0"
+    aws-cdk-lib "2.20.0"
+    aws-sdk "^2.1113.0"
     chalk "^4.1.2"
-    cli-ux "^5.6.6"
     codemaker "^1.55.1"
+    constructs "10.0.110"
     git-url-parse "^11.6.0"
     inquirer "^8.2.2"
     lodash.camelcase "^4.3.0"
@@ -1676,87 +864,50 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@oclif/command@^1.8.15":
-  version "1.8.16"
-  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.16.tgz#bea46f81b2061b47e1cda318a0b923e62ca4cc0c"
-  integrity sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==
+"@oclif/core@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.7.0.tgz#3b763b53eafa9afbb13cf7cdfeac0f8ddd8ab1af"
+  integrity sha512-I4q4qgtnNG7ef4sBDrJhwADdi7RExQV7LnflnXaWZZDiUoqF9AdOjC4jjx40MK0rRrCehCUtPNZBcr3WmxuS4Q==
   dependencies:
-    "@oclif/config" "^1.18.2"
-    "@oclif/errors" "^1.3.5"
-    "@oclif/help" "^1.0.1"
-    "@oclif/parser" "^3.8.6"
-    debug "^4.1.1"
-    semver "^7.3.2"
-
-"@oclif/config@1.18.2":
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.2.tgz#5bfe74a9ba6a8ca3dceb314a81bd9ce2e15ebbfe"
-  integrity sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==
-  dependencies:
-    "@oclif/errors" "^1.3.3"
-    "@oclif/parser" "^3.8.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-wsl "^2.1.1"
-    tslib "^2.0.0"
-
-"@oclif/config@^1.18.2":
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.3.tgz#ddfc144fdab66b1658c2f1b3478fa7fbfd317e79"
-  integrity sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==
-  dependencies:
-    "@oclif/errors" "^1.3.5"
-    "@oclif/parser" "^3.8.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-wsl "^2.1.1"
-    tslib "^2.3.1"
-
-"@oclif/errors@1.3.5", "@oclif/errors@^1.3.3", "@oclif/errors@^1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
-  integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==
-  dependencies:
-    clean-stack "^3.0.0"
-    fs-extra "^8.1"
-    indent-string "^4.0.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
-
-"@oclif/help@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@oclif/help/-/help-1.0.1.tgz#fd96a3dd9fb2314479e6c8584c91b63754a7dff5"
-  integrity sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==
-  dependencies:
-    "@oclif/config" "1.18.2"
-    "@oclif/errors" "1.3.5"
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^3.0.2"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
     chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.10.0"
+    debug "^4.3.3"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
     indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
     lodash "^4.17.21"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.3.5"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.3.1"
     widest-line "^3.1.0"
-    wrap-ansi "^6.2.0"
+    wrap-ansi "^7.0.0"
 
 "@oclif/linewrap@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.6":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.7.tgz#236d48db05d0b00157d3b42d31f9dac7550d2a7c"
-  integrity sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==
-  dependencies:
-    "@oclif/errors" "^1.3.5"
-    "@oclif/linewrap" "^1.0.0"
-    chalk "^4.1.0"
-    tslib "^2.3.1"
-
-"@oclif/screen@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
-  integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
+"@oclif/screen@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.2.tgz#969054308fe98d130c02844a45cc792199b75670"
+  integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
@@ -2074,7 +1225,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-escapes@^4.3.0:
+ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -2098,7 +1249,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -2165,6 +1316,11 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2175,17 +1331,32 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk@1.152.0:
-  version "1.152.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.152.0.tgz#d679871a5bfe3d926f0b7883429f340b82df5d0a"
-  integrity sha512-iAuTEBAZp78gmW6w2VKCWZ2/pHFc6OAIz07cO4xiTImDWYy5uKyN+rVOKpy1wdUEUZfcI85eKMeZvFubra8uZA==
+aws-cdk-lib@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.20.0.tgz#bb22702cc3748d8ed7eb42646f473ff740311bfe"
+  integrity sha512-jACK/1UJxtWWl6QH+I1V8Oc8F1EEL6aFQYk24DIrzNyB1Aj9LIs9/NyDu5zN00QFKrR6aDE7WAv1VG3sa6wWdg==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^9.1.0"
+    ignore "^5.2.0"
+    jsonschema "^1.4.0"
+    minimatch "^3.1.2"
+    punycode "^2.1.1"
+    semver "^7.3.5"
+    yaml "1.10.2"
+
+aws-cdk@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.20.0.tgz#e3b00ecd1589777bebd1d003e32479cbfad735e1"
+  integrity sha512-rs9LTpvrlbsMcenZ3t7TuLDGbHhbnDocrE63Xb2PT++VptR/A8svllK8k1W7hPl77L9QS75GNK5gh+ShkEzsnw==
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1109.0:
-  version "2.1111.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1111.0.tgz#02b1e5c530ef8140235ee7c48c710bb2dbd7dc84"
-  integrity sha512-WRyNcCckzmu1djTAWfR2r+BuI/PbuLrhG3oa+oH39v4NZ4EecYWFL1CoCPlC2kRUML4maSba5T4zlxjcNl7ELQ==
+aws-sdk@^2.1113.0:
+  version "2.1118.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1118.0.tgz#1789e881b1f43bef7807111d5716ab691ab965c2"
+  integrity sha512-R3g06c4RC0Gz/lwMA7wgC7+FwYf5vaO30sPIigoX5m6Tfb7tdzfCYD7pnpvkPRNUvWJ3f5kQk+pEeW25DstRrQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2284,6 +1455,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.1:
   version "3.0.2"
@@ -2393,6 +1571,11 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
+case@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2402,7 +1585,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+chalk@^4, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2443,7 +1626,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-clean-stack@^3.0.0:
+clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
@@ -2457,7 +1640,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-progress@^3.4.0:
+cli-progress@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.10.0.tgz#63fd9d6343c598c93542fdfa3563a8b59887d78a"
   integrity sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==
@@ -2468,38 +1651,6 @@ cli-spinners@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
-
-cli-ux@^5.6.6:
-  version "5.6.7"
-  resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.7.tgz#32ef9e6cb2b457be834280cc799028a11c8235a8"
-  integrity sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==
-  dependencies:
-    "@oclif/command" "^1.8.15"
-    "@oclif/errors" "^1.3.5"
-    "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^1.0.4"
-    ansi-escapes "^4.3.0"
-    ansi-styles "^4.2.0"
-    cardinal "^2.1.1"
-    chalk "^4.1.0"
-    clean-stack "^3.0.0"
-    cli-progress "^3.4.0"
-    extract-stack "^2.0.0"
-    fs-extra "^8.1"
-    hyperlinker "^1.0.0"
-    indent-string "^4.0.0"
-    is-wsl "^2.2.0"
-    js-yaml "^3.13.1"
-    lodash "^4.17.21"
-    natural-orderby "^2.0.1"
-    object-treeify "^1.1.4"
-    password-prompt "^1.1.2"
-    semver "^7.3.2"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    supports-color "^8.1.0"
-    supports-hyperlinks "^2.1.0"
-    tslib "^2.0.0"
 
 cli-width@^3.0.0:
   version "3.0.0"
@@ -2579,6 +1730,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+constructs@10.0.110:
+  version "10.0.110"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.110.tgz#f5563efca14648ddb7c633dc1b4369ac30f743fb"
+  integrity sha512-Ojh53qbHi5XxkOFd7acUQebVzEn00KXF93YRwd5vii7tiVrkjgufWPl5NgdhNmvmC/lcQ1w8ke77PN37gQdgoQ==
 
 constructs@^3.3.69:
   version "3.3.71"
@@ -2668,6 +1824,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^5.0.1:
   version "5.0.1"
@@ -2765,6 +1928,13 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+ejs@^3.1.6:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.7.tgz#c544d9c7f715783dd92f0bddcf73a59e6962d006"
+  integrity sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==
+  dependencies:
+    jake "^10.8.5"
 
 electron-to-chromium@^1.3.723:
   version "1.3.785"
@@ -3100,11 +2270,6 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extract-stack@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-2.0.0.tgz#11367bc865bfcd9bc0db3123e5edb57786f11f9b"
-  integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3176,6 +2341,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+filelist@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.3.tgz#448607750376484932f67ef1b9ff07386b036c83"
+  integrity sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==
+  dependencies:
+    minimatch "^5.0.1"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -3224,15 +2396,6 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-fs-extra@^8.1:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -3348,18 +2511,6 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.1:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
-  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.9"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^3.0.0"
-
 globby@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
@@ -3370,6 +2521,18 @@ globby@^11.0.3:
     fast-glob "^3.1.1"
     ignore "^5.1.4"
     merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
@@ -3708,7 +2871,7 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-wsl@^2.1.1, is-wsl@^2.2.0:
+is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -3765,6 +2928,16 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
 
 jest-changed-files@^27.3.0:
   version "27.3.0"
@@ -4226,6 +3399,14 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsdom@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.6.0.tgz#f79b3786682065492a3da6a60a4695da983805ac"
@@ -4302,13 +3483,6 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -4520,6 +3694,13 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -4545,7 +3726,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-natural-orderby@^2.0.1:
+natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
@@ -4617,7 +3798,7 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-treeify@^1.1.4:
+object-treeify@^1.1.33:
   version "1.1.33"
   resolved "https://registry.yarnpkg.com/object-treeify/-/object-treeify-1.1.33.tgz#f06fece986830a3cba78ddd32d4c11d1f76cdf40"
   integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
@@ -5407,7 +4588,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.0:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -5422,7 +4603,7 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-supports-hyperlinks@^2.1.0:
+supports-hyperlinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
@@ -5584,7 +4765,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.1:
+tslib@^2.1.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -5662,7 +4843,7 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-universalify@^0.1.0, universalify@^0.1.2:
+universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
@@ -5823,15 +5004,6 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Upgrades CDK now that the changes here (https://github.com/guardian/amiable/pull/122) are included in CDK itself (see https://github.com/guardian/cdk/releases/tag/v41.1.0).

Note, the @guardian/cdk upgrade also bumps AWS CDK to v2 with associated changes - see https://github.com/guardian/cdk/releases/tag/v41.0.0 for details here.