### PR TITLE
Ship application logs to ELK using devx-logs prototype

### DIFF
--- a/app/controllers/Healthcheck.scala
+++ b/app/controllers/Healthcheck.scala
@@ -1,10 +1,12 @@
 package controllers
 
+import play.api.Logging
 import play.api.mvc._
 
-class Healthcheck(val controllerComponents: ControllerComponents) extends BaseController {
+class Healthcheck(val controllerComponents: ControllerComponents) extends BaseController with Logging {
 
   def healthcheck: Action[AnyContent] = Action {
+    logger.info("Healthcheck was successful")
     Ok("ok")
   }
 

--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -108,6 +108,11 @@ Object {
             "PropagateAtLaunch": true,
             "Value": "CODE",
           },
+          Object {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "amiable.service",
+          },
         ],
         "TargetGroupARNs": Array [
           Object {

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -5,6 +5,7 @@ import { GuAllowPolicy, GuSESSenderPolicy } from "@guardian/cdk/lib/constructs/i
 import { GuPlayApp } from "@guardian/cdk/lib/patterns/ec2-app";
 import { GuardianPublicNetworks } from "@guardian/private-infrastructure-config";
 import type { App } from "aws-cdk-lib";
+import { Tags } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, Peer } from "aws-cdk-lib/aws-ec2";
 
 interface AmiableProps extends GuStackProps {
@@ -23,7 +24,7 @@ export class Amiable extends GuStack {
       GuardianPublicNetworks.NewYork2,
     ];
 
-    new GuPlayApp(this, {
+    const playApp = new GuPlayApp(this, {
       app: this.app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
       userData: `#!/bin/bash -ev
@@ -51,5 +52,7 @@ export class Amiable extends GuStack {
       accessLogging: { enabled: true, prefix: `ELBLogs/${this.stack}/${this.app}/${this.stage}` },
       scaling: { minimumInstances: 1 },
     });
+
+    Tags.of(playApp.autoScalingGroup).add("SystemdUnit", `${this.app}.service`);
   }
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,21 +1,14 @@
 <configuration>
-    
+
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel - %logger - %message%n%xException</pattern>
+      <pattern>%-5level - %logger - %message%n%xException</pattern>
     </encoder>
   </appender>
 
-  <!--
-    The logger name is typically the Java/Scala package name.
-    This configures the log level to log at for a package and its children packages.
-  -->
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-
-  <root level="ERROR">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure-test
+        Recipe: arm64-bionic-java8-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure
+        Recipe: arm64-bionic-java8-deploy-infrastructure-test
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
Follow up to https://github.com/guardian/amiable/pull/122, which started shipping the `cloud-init-output.log` to ELK.

This PR adds the required tagging (https://github.com/guardian/amiable/pull/127/commits/8374d9b8464fafca318e5a5cab28524bfd1adab0) to ship application logs in conjunction with https://github.com/guardian/devx-logs/pull/11. You can see that working [here](https://logs.gutools.co.uk/s/devx/goto/2c5f27e0-c572-11ec-bf09-35dccc95800f).

I've also made some small changes to Amiable's logging configuration (and deliberately made the logs a little noisier) in order to test this change.

In the future I suggest that `@guardian/cdk` takes care of the necessary infrastructure changes (https://github.com/guardian/amiable/pull/127/commits/8374d9b8464fafca318e5a5cab28524bfd1adab0) for users. We'll need to consider whether to make this opt-in or opt-out (it's a best practice and we want all new stacks to have it by default, but most teams are already logging via other means and will want this turned off initially, so there are trade-offs here).