### PR TITLE
Change log format to JSON

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,27 @@ scalacOptions := Seq(
   "-Ywarn-unused"
 )
 
+// https://github.com/orgs/playframework/discussions/11222
+val jacksonVersion         = "2.13.2"
+val jacksonDatabindVersion = "2.13.2.2"
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core",
+  "com.fasterxml.jackson.core"     % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala",
+).map(_ % jacksonVersion)
+
 libraryDependencies ++= Seq(
   jdbc,
   ehcache,
@@ -47,8 +68,9 @@ libraryDependencies ++= Seq(
   specs2 % Test,
   "org.scalatest" %% "scalatest" % "3.2.10" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "4.2.0" % Test
-)
+  "org.mockito" % "mockito-core" % "4.2.0" % Test,
+  "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1"
+) ++ jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
 
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,9 +3,7 @@
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%-5level - %logger - %message%n%xException</pattern>
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
   </appender>
 
   <root level="INFO">

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.6.2


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Change logging format to output as JSON. Combined with https://github.com/guardian/devx-logs/pull/16, this means we'll get structured logging in Central ELK 🎉 .

The Jackson changes are not ideal. Without these changes we get:

```console
[error] com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.11.4 requires Jackson Databind version >= 2.11.0 and < 2.12.0
```

Following the advice from https://github.com/orgs/playframework/discussions/11222 was the only solution we could find. We'll attempt to find a better solution in a future PR.