### PR TITLE
feat: Allow pre-PROD environments to read PROD's cloudwatch metrics

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -47,10 +47,10 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
 
   lazy val amiableConfigProvider = new AmiableConfigProvider(wsClient, configuration, httpConfiguration)
 
-  val cloudwatch = new CloudWatch(amiableConfigProvider.stage)
+  val cloudwatch = new CloudWatch()
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
-  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, agents, applicationLifecycle)
+  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
 
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -50,7 +50,7 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
   val cloudwatch = new CloudWatch()
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
-  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
+  val metrics = new Metrics(cloudwatch, amiableConfigProvider.shouldCreateCloudwatchMetrics, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
 
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync

--- a/app/config/AMIableConfig.scala
+++ b/app/config/AMIableConfig.scala
@@ -43,7 +43,18 @@ class AmiableConfigProvider @Inject() (val ws: WSClient, val playConfig: Configu
     playConfig, "stage"
   )
 
-  val cloudwatchReadNamespace: String = s"AMIable-$stage"
+  /**
+    * Cloudwatch metrics are expensive.
+    * Our pre-PROD environments do not get much traffic, so in order to reduce AWS spend, only create metrics in PROD.
+    */
+  val shouldCreateCloudwatchMetrics: Boolean = stage == "PROD"
+
+  /**
+    * If our pre-PROD environments are not creating metrics, have them read PROD's so the app can be fully tested.
+    * @see [[`shouldCreateCloudwatchMetrics`]]
+    */
+  val cloudwatchReadNamespace: String = if (shouldCreateCloudwatchMetrics) s"AMIable-$stage" else s"AMIable-PROD"
+
   val cloudwatchWriteNamespace: String = s"AMIable-$stage"
   val cloudwatchSecurityHqNamespace: String = "SecurityHQ"
 

--- a/app/config/AMIableConfig.scala
+++ b/app/config/AMIableConfig.scala
@@ -43,6 +43,10 @@ class AmiableConfigProvider @Inject() (val ws: WSClient, val playConfig: Configu
     playConfig, "stage"
   )
 
+  val cloudwatchReadNamespace: String = s"AMIable-$stage"
+  val cloudwatchWriteNamespace: String = s"AMIable-$stage"
+  val cloudwatchSecurityHqNamespace: String = "SecurityHQ"
+
   val requiredGoogleGroups: Set[String] = Set(requiredString(playConfig, "auth.google.2faGroupId"))
 
   val googleAuthConfig: GoogleAuthConfig = {

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -140,7 +140,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   }
 
   private def refreshHistory(agent: Agent[List[(DateTime, Double)]], metricName:String): Unit = {
-    cloudWatch.get(metricName).fold(
+    cloudWatch.get(amiableConfigProvider.cloudwatchReadNamespace, metricName).fold(
       { err =>
         logger.warn(s"Failed to update historical data for metric '$metricName': ${err.logString}")
       },

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -8,10 +8,8 @@ import rx.lang.scala.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(cloudWatch: CloudWatch, stage: String, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
-
-  // only add metrics from PROD
-  if (stage == "PROD") {
+class Metrics(cloudWatch: CloudWatch, shouldCreateMetrics: Boolean, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
+  if (shouldCreateMetrics) {
 
     val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
       cloudWatch.put(namespace, CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -18,6 +18,9 @@ class Metrics(cloudWatch: CloudWatch, shouldCreateMetrics: Boolean, namespace: S
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+
+      // These metrics are used by a Grafana dashboard which graphs SecurityHQ related metrics
+      // TODO use the same namespace as other metrics, and filter in Grafana instead?
       cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -8,19 +8,19 @@ import rx.lang.scala.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(cloudWatch: CloudWatch, stage: String, agents: Agents, lifecycle: ApplicationLifecycle) {
+class Metrics(cloudWatch: CloudWatch, stage: String, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
 
   // only add metrics from PROD
   if (stage == "PROD") {
 
     val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
-      cloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
-      cloudWatch.put(CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
+      cloudWatch.put(namespace, CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+      cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 
     lifecycle.addStopHook { () =>

--- a/test/metrics/CloudWatchTest.scala
+++ b/test/metrics/CloudWatchTest.scala
@@ -10,10 +10,10 @@ import scala.collection.JavaConverters._
 
 
 class CloudWatchTest extends AnyFreeSpec with Matchers with OptionValues {
-  val cloudwatch = new CloudWatch("TEST")
+  val cloudwatch = new CloudWatch()
   "putRequest" - {
     "sets provided count value" in {
-      val metricDataRequest = cloudwatch.putRequest("test-metric", 5)
+      val metricDataRequest = cloudwatch.putRequest("test-namespace","test-metric", 5)
       val metricDatum = metricDataRequest.getMetricData.asScala.headOption.value
       metricDatum.getValue shouldEqual 5
     }


### PR DESCRIPTION
Likely to be easiest reviewed commit by commit.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As seen in #133, we're currently only producing cloudwatch metrics in PROD. This means the graph on the index page in pre-PROD environments will be empty.

In this change we let pre-PROD environments read cloudwatch metrics from the PROD namespace, fixing the graph on the index page.

We also push the namespace of our cloudwatch metrics into configuration for clarity and add a `TODO` against a metric that [uses a different namespace](#60), which was a little confusing.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

When deployed to CODE, we should see data on the index page's graph.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Spotting regressions in pre-PROD becomes easier? This is true at least for #133.