### PR TITLE
feat: Produce CloudWatch Metrics for every stage, not just `PROD`

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -50,7 +50,7 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
   val cloudwatch = new CloudWatch()
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
-  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
+  val metrics = new Metrics(cloudwatch, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
 
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -47,10 +47,10 @@ class AppComponents(context: Context) extends play.api.BuiltInComponentsFromCont
 
   lazy val amiableConfigProvider = new AmiableConfigProvider(wsClient, configuration, httpConfiguration)
 
-  val cloudwatch = new CloudWatch(amiableConfigProvider.stage)
+  val cloudwatch = new CloudWatch()
 
   val agents = new Agents(amiableConfigProvider, applicationLifecycle, actorSystem, environment, cloudwatch)
-  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, agents, applicationLifecycle)
+  val metrics = new Metrics(cloudwatch, amiableConfigProvider.stage, amiableConfigProvider.cloudwatchWriteNamespace, amiableConfigProvider.cloudwatchSecurityHqNamespace, agents, applicationLifecycle)
 
 
   lazy val amazonMailClient: AmazonSimpleEmailServiceAsync = amazonSimpleEmailServiceAsync

--- a/app/config/AMIableConfig.scala
+++ b/app/config/AMIableConfig.scala
@@ -43,6 +43,10 @@ class AmiableConfigProvider @Inject() (val ws: WSClient, val playConfig: Configu
     playConfig, "stage"
   )
 
+  val cloudwatchReadNamespace: String = s"AMIable-$stage"
+  val cloudwatchWriteNamespace: String = s"AMIable-$stage"
+  val cloudwatchSecurityHqNamespace: String = "SecurityHQ"
+
   val requiredGoogleGroups: Set[String] = Set(requiredString(playConfig, "auth.google.2faGroupId"))
 
   val googleAuthConfig: GoogleAuthConfig = {

--- a/app/services/Agents.scala
+++ b/app/services/Agents.scala
@@ -140,7 +140,7 @@ class Agents @Inject() (amiableConfigProvider: AmiableConfigProvider, lifecycle:
   }
 
   private def refreshHistory(agent: Agent[List[(DateTime, Double)]], metricName:String): Unit = {
-    cloudWatch.get(metricName).fold(
+    cloudWatch.get(amiableConfigProvider.cloudwatchReadNamespace, metricName).fold(
       { err =>
         logger.warn(s"Failed to update historical data for metric '$metricName': ${err.logString}")
       },

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -20,6 +20,9 @@ class Metrics(cloudWatch: CloudWatch, stage: String, namespace: String, security
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
       cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+
+      // These metrics are used by a Grafana dashboard which graphs SecurityHQ related metrics
+      // TODO use the same namespace as other metrics, and filter in Grafana instead?
       cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -2,33 +2,27 @@ package services
 
 import metrics.{CloudWatch, CloudWatchMetrics}
 import play.api.inject.ApplicationLifecycle
-import play.api.{Environment, Mode}
-import rx.lang.scala.Observable
+import rx.lang.scala.{Observable, Subscription}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(cloudWatch: CloudWatch, stage: String, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
+class Metrics(cloudWatch: CloudWatch, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
+  val subscription: Subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
+    cloudWatch.put(namespace, CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
+    cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
+    cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
+    cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
+    cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
+    cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
 
-  // only add metrics from PROD
-  if (stage == "PROD") {
+    // These metrics are used by a Grafana dashboard which graphs SecurityHQ related metrics
+    // TODO use the same namespace as other metrics, and filter in Grafana instead?
+    cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
+  }
 
-    val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
-      cloudWatch.put(namespace, CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
-      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
-      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
-      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
-      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
-      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
-
-      // These metrics are used by a Grafana dashboard which graphs SecurityHQ related metrics
-      // TODO use the same namespace as other metrics, and filter in Grafana instead?
-      cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
-    }
-
-    lifecycle.addStopHook { () =>
-      subscription.unsubscribe()
-      Future.successful(())
-    }
+  lifecycle.addStopHook { () =>
+    subscription.unsubscribe()
+    Future.successful(())
   }
 }

--- a/app/services/Metrics.scala
+++ b/app/services/Metrics.scala
@@ -8,19 +8,19 @@ import rx.lang.scala.Observable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class Metrics(cloudWatch: CloudWatch, stage: String, agents: Agents, lifecycle: ApplicationLifecycle) {
+class Metrics(cloudWatch: CloudWatch, stage: String, namespace: String, securityHqNamespace: String, agents: Agents, lifecycle: ApplicationLifecycle) {
 
   // only add metrics from PROD
   if (stage == "PROD") {
 
     val subscription = Observable.interval(initialDelay = 10.seconds, period = 6.hours).subscribe { _ =>
-      cloudWatch.put(CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
-      cloudWatch.put(CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
-      cloudWatch.put(CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
+      cloudWatch.put(namespace, CloudWatchMetrics.OldCount.name, agents.oldProdInstanceCount)
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile25th.name, agents.amisAgePercentiles.flatMap(_.p25))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile50th.name, agents.amisAgePercentiles.flatMap(_.p50))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile75th.name, agents.amisAgePercentiles.flatMap(_.p75))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentile90th.name, agents.amisAgePercentiles.flatMap(_.p90))
+      cloudWatch.put(namespace, CloudWatchMetrics.AmisAgePercentileHighest.name, agents.amisAgePercentiles.flatMap(_.highest))
+      cloudWatch.put(securityHqNamespace, CloudWatchMetrics.OldCountByAccount.name, agents.oldInstanceCountByAccount)
     }
 
     lifecycle.addStopHook { () =>

--- a/test/metrics/CloudWatchTest.scala
+++ b/test/metrics/CloudWatchTest.scala
@@ -10,10 +10,10 @@ import scala.collection.JavaConverters._
 
 
 class CloudWatchTest extends AnyFreeSpec with Matchers with OptionValues {
-  val cloudwatch = new CloudWatch("TEST")
+  val cloudwatch = new CloudWatch()
   "putRequest" - {
     "sets provided count value" in {
-      val metricDataRequest = cloudwatch.putRequest("test-metric", 5)
+      val metricDataRequest = cloudwatch.putRequest("test-namespace","test-metric", 5)
       val metricDatum = metricDataRequest.getMetricData.asScala.headOption.value
       metricDatum.getValue shouldEqual 5
     }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A replacement for #137, this change updates AMIable to always produce CloudWatch Metrics (currently metrics are only produced in PROD).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler, more obvious behaviour?

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We're currently shipping metrics to two namespaces:
  1. `AMIable-<STAGE>`
  2. `SecurityHQ`

The second namespace will now have twice the number of metrics for the same data with no identity as to what produced it. Will this cause confusion?