### PR TITLE
Bump instance size to small

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -146,7 +146,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIAmiable",
         },
-        "InstanceType": "t4g.micro",
+        "InstanceType": "t4g.small",
         "MetadataOptions": Object {
           "HttpTokens": "required",
         },
@@ -1029,7 +1029,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIAmiable",
         },
-        "InstanceType": "t4g.micro",
+        "InstanceType": "t4g.small",
         "MetadataOptions": Object {
           "HttpTokens": "required",
         },

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -25,7 +25,7 @@ export class Amiable extends GuStack {
 
     new GuPlayApp(this, {
       app: this.app,
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
       userData: `#!/bin/bash -ev
 
           mkdir /amiable


### PR DESCRIPTION
## What does this change?
Moves the instance size from micro to small, because we are seeing some instability. CPU appears to spike before the instance becomes unresponsive and perhaps they are being overwhelmed during the scheduled tasks occasionally. If this does not solve the issue it will also be useful information.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->