### PR TITLE
Switch to new dependency update branch to reset Scala Steward

### DIFF
--- a/.github/workflows/pr-tracking-branch.yml
+++ b/.github/workflows/pr-tracking-branch.yml
@@ -10,3 +10,5 @@ jobs:
   pr-tracking-branch:
     name: Open a PR from dependency-updates targeting main
     uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1
+    with:
+      BRANCH: dependency-updates_1

--- a/.github/workflows/set-automerge.yml
+++ b/.github/workflows/set-automerge.yml
@@ -3,7 +3,7 @@ name: Auto-merge dependency updates to tracking branch
 on:
   pull_request:
     branches:
-      - dependency-updates
+      - dependency-updates_1
 
 jobs:
   set-automerge:

--- a/.github/workflows/tracking-branch.yml
+++ b/.github/workflows/tracking-branch.yml
@@ -9,3 +9,5 @@ jobs:
   update-dependency-update-branch:
     name: Keep tracking branch up to date with main
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1
+    with:
+      BRANCH: "dependency-updates_1"


### PR DESCRIPTION
My testing of the workflow introduced in https://github.com/guardian/amiable/pull/182 was using the same branch we ended up using after release. This meant that Scala Steward detected already open PRs for a number updates, and did not create them fresh. As those PRs contained conflicts that needed individually resolving, I decided it would be quicker to reset by using a different branch for the dependency updates.