### PR TITLE
Update dependency update workflow to latest

### DIFF
--- a/.github/workflows/pr-tracking-branch.yml
+++ b/.github/workflows/pr-tracking-branch.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   pr-tracking-branch:
     name: Open a PR from dependency-updates targeting main
-    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.1
     with:
       BRANCH: dependency-updates_1

--- a/.github/workflows/set-automerge.yml
+++ b/.github/workflows/set-automerge.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   set-automerge:
     name: Set automerge on opened PRs targeting the tracking branch
-    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.1

--- a/.github/workflows/tracking-branch.yml
+++ b/.github/workflows/tracking-branch.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   update-dependency-update-branch:
     name: Keep tracking branch up to date with main
-    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1
+    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1
     with:
       BRANCH: "dependency-updates_1"


### PR DESCRIPTION
## What does this change?
Updates to the latest version of the reusable workflows for batching dependency updates. With that, we get more resilient merge/rebasing operations after some minor tweaks to those workflows.