### PR TITLE
Bump to Scala 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.0-SNAPSHOT"
 
 enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
 
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.10"
 
 Universal / javaOptions ++= Seq(
   "-Dpidfile.path=/dev/null",


### PR DESCRIPTION
To address https://github.com/scala/bug/issues/12650 (though no specific evidence this project is vulnerable) and also test out Nori for a wider bump across repos.