### PR TITLE
refactor: Remove explicit bucket name from user data

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -165,14 +165,33 @@ Object {
           },
         ],
         "UserData": Object {
-          "Fn::Base64": "#!/bin/bash -ev
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash -ev
 
           mkdir /amiable
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/CODE/amiable/conf/amiable-service-account-cert.json /amiable/
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/CODE/amiable/conf/amiable.conf /etc/
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/CODE/amiable/amiable.deb /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/CODE/amiable/conf/amiable-service-account-cert.json /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/CODE/amiable/conf/amiable.conf /etc/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/CODE/amiable/amiable.deb /amiable/
 
           dpkg -i /amiable/amiable.deb",
+              ],
+            ],
+          },
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
@@ -1048,14 +1067,33 @@ Object {
           },
         ],
         "UserData": Object {
-          "Fn::Base64": "#!/bin/bash -ev
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash -ev
 
           mkdir /amiable
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/PROD/amiable/conf/amiable-service-account-cert.json /amiable/
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/PROD/amiable/conf/amiable.conf /etc/
-          aws --region eu-west-1 s3 cp s3://deploy-tools-dist/deploy/PROD/amiable/amiable.deb /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/PROD/amiable/conf/amiable-service-account-cert.json /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/PROD/amiable/conf/amiable.conf /etc/
+          aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/PROD/amiable/amiable.deb /amiable/
 
           dpkg -i /amiable/amiable.deb",
+              ],
+            ],
+          },
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Get the bucket name from the SSM Parameter `/account/services/artifact.bucket`, in line with our recommendations and best practice.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy it?!