### PR TITLE
Fix to allow Scala Steward to monitor dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,14 @@ libraryDependencies ++= Seq(
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2"
 ) ++ jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
 
+/*
+ * This is required for Scala Steward to run until SBT plugins all migrated to scala-xml 2.
+ * See https://github.com/scala-steward-org/scala-steward/blob/13d63e8ae98a714efcdac2c7af18f004130512fa/project/plugins.sbt#L16-L19
+ */
+libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)
+
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
 PlayKeys.playDefaultPort := 9101


### PR DESCRIPTION
Recent Scala Steward runs have been failing because of incompatibilities between versions of scala-xml.

Eg. https://github.com/guardian/scala-steward-public-repos/actions/runs/3378212621/jobs/5608120855#step:5:64
![image](https://user-images.githubusercontent.com/1722550/199517807-10302fa3-903c-46f8-9207-260fc999b72a.png)
