### PR TITLE
chore: Tune Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,12 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/cdk'
-    # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
+    # The version of AWS CDK libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
       - dependency-name: "aws-cdk"
-      - dependency-name: "@aws-cdk/*"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"
     # The cdk directory does not run in a PROD environment, only CI, so we can afford to use old versions of libraries for a short time. Run Dependabot once a month to reduce the frequency of PRs.
     schedule:
       interval: 'monthly'


### PR DESCRIPTION
The version of AWS CDK libraries must match those from @guardian/cdk. We'd never be able to update them here independently, so just ignore them.