### PR TITLE
Check membership of P&E Google Group

### DIFF
--- a/app/config/AMIableConfig.scala
+++ b/app/config/AMIableConfig.scala
@@ -58,7 +58,10 @@ class AmiableConfigProvider @Inject() (val ws: WSClient, val playConfig: Configu
   val cloudwatchWriteNamespace: String = s"AMIable-$stage"
   val cloudwatchSecurityHqNamespace: String = "SecurityHQ"
 
-  val requiredGoogleGroups: Set[String] = Set(requiredString(playConfig, "auth.google.2faGroupId"))
+  val requiredGoogleGroups: Set[String] = Set(
+    requiredString(playConfig, "auth.google.2faGroupId"),
+    requiredString(playConfig, "auth.google.departmentGroupId")
+  )
 
   val googleAuthConfig: GoogleAuthConfig = {
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,6 +69,7 @@ auth {
     clientSecret=${GOOGLE_CLIENT_SECRET}
     2faUser=${GOOGLE_2FA_USER}
     2faGroupId=${2FA_GROUP_ID}
+    departmentGroupId=${DEPARTMENT_GROUP_ID}
   }
 }
 


### PR DESCRIPTION
## What does this change?

This PR adds some additional config to AMIable which allows us to confirm that the user is a member of P&E (based on Google Group) before granting them access to the tool.

Note that this tool is still locked down using security groups and this PR does not modify these - that will happen via a follow-up PR.

## How to test

Added test Google Group as the `DEPARTMENT_GROUP_ID` value in `CODE`:

- [x] Confirmed that a member of the test group could still access AMIable
- [x] Confirmed that a non-member can no longer access AMIable

Note that if the user is not in the appropriate Google Group they are not given access to the tool, but they are sent into a redirect loop rather than being shown a helpful error message. We believe this is a pre-existing bug but it may be confusing!

Added the correct Google Group as the `DEPARTMENT_GROUP_ID` value in `CODE`:

- [x] Confirmed that I could still access AMIable

## How can we measure success?

This is an InfoSec requirement for making AMIable available on the public internet.

## Have we considered potential risks?

If we configure this incorrectly we will a) unintentionally block trusted users from accessing the tool or b) unintentionally allow too many users from accessing the tool. The testing described above should check for both of these cases.

## Steps taken outside of version control

- [x] Add `DEPARTMENT_GROUP_ID` value in private AMIable config for `CODE`
- [x] Add `DEPARTMENT_GROUP_ID` value in private AMIable config for `PROD`