### PR TITLE
Make ALB accessible to all ip addresses

### DIFF
--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,2 +1,1 @@
 jest.mock("@guardian/cdk/lib/constants/tracking-tag");
-jest.mock("@guardian/private-infrastructure-config");

--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -28,7 +28,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuSecurityGroup",
       "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
@@ -420,27 +419,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "GuHttpsEgressSecurityGroupAmiablefromamiableRestrictedIngressSecurityGroupAmiableFA2DDED29000D4E8B76E": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupAmiable42C3598C",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupAmiableF2034457",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "GuHttpsEgressSecurityGroupAmiablefromamiableldpaccessAmiable1EDD8FAB9000558E233C": {
       "Properties": {
         "Description": "Load balancer to target",
@@ -652,12 +630,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
           },
           {
             "Fn::GetAtt": [
-              "RestrictedIngressSecurityGroupAmiableF2034457",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
               "ldpaccessAmiable1869C179",
               "GroupId",
             ],
@@ -695,6 +667,15 @@ exports[`The Amiable stack matches the snapshot 1`] = `
     "LoadBalancerAmiableSecurityGroupAE4F7AF8": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB amiableLoadBalancerAmiableD818374E",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -794,81 +775,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "RestrictedIngressSecurityGroupAmiableF2034457": {
-      "Properties": {
-        "GroupDescription": "Allow restricted ingress from CIDR ranges",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "192.168.1.1/22",
-            "Description": "Allow access on port 443 from 192.168.1.1/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-          {
-            "CidrIp": "192.168.1.2/22",
-            "Description": "Allow access on port 443 from 192.168.1.2/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-          {
-            "CidrIp": "192.168.1.3/22",
-            "Description": "Allow access on port 443 from 192.168.1.3/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "amiable",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/amiable",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "RestrictedIngressSecurityGroupAmiabletoamiableGuHttpsEgressSecurityGroupAmiable7C2576F69000C038BE6D": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupAmiable42C3598C",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupAmiableF2034457",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "SSMRunCommandPolicy244E1613": {
       "Properties": {
@@ -1091,7 +997,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "GuStringParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuSecurityGroup",
       "GuAlb5xxPercentageAlarm",
       "GuUnhealthyInstancesAlarm",
       "GuCname",
@@ -1485,27 +1390,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "GuHttpsEgressSecurityGroupAmiablefromAmiablePRODRestrictedIngressSecurityGroupAmiable2EAC591090005722D016": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupAmiable42C3598C",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupAmiableF2034457",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "GuHttpsEgressSecurityGroupAmiablefromAmiablePRODldpaccessAmiable77AFE83C90002BD662C0": {
       "Properties": {
         "Description": "Load balancer to target",
@@ -1819,12 +1703,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
           },
           {
             "Fn::GetAtt": [
-              "RestrictedIngressSecurityGroupAmiableF2034457",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
               "ldpaccessAmiable1869C179",
               "GroupId",
             ],
@@ -1862,6 +1740,15 @@ exports[`The Amiable stack matches the snapshot 2`] = `
     "LoadBalancerAmiableSecurityGroupAE4F7AF8": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB AmiablePRODLoadBalancerAmiable081EFE48",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -1961,81 +1848,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "RestrictedIngressSecurityGroupAmiableF2034457": {
-      "Properties": {
-        "GroupDescription": "Allow restricted ingress from CIDR ranges",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "192.168.1.1/22",
-            "Description": "Allow access on port 443 from 192.168.1.1/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-          {
-            "CidrIp": "192.168.1.2/22",
-            "Description": "Allow access on port 443 from 192.168.1.2/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-          {
-            "CidrIp": "192.168.1.3/22",
-            "Description": "Allow access on port 443 from 192.168.1.3/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "amiable",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/amiable",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "RestrictedIngressSecurityGroupAmiabletoAmiablePRODGuHttpsEgressSecurityGroupAmiableB48C77C89000768D85C3": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupAmiable42C3598C",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupAmiableF2034457",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "SSMRunCommandPolicy244E1613": {
       "Properties": {

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -5,7 +5,6 @@ import {GuCname} from "@guardian/cdk/lib/constructs/dns";
 import { GuHttpsEgressSecurityGroup } from "@guardian/cdk/lib/constructs/ec2";
 import { GuAllowPolicy, GuSESSenderPolicy } from "@guardian/cdk/lib/constructs/iam";
 import { GuPlayApp } from "@guardian/cdk/lib/patterns/ec2-app";
-import { GuardianPublicNetworks } from "@guardian/private-infrastructure-config";
 import type { App } from "aws-cdk-lib";
 import {Duration, SecretValue} from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, Peer } from "aws-cdk-lib/aws-ec2";
@@ -24,12 +23,6 @@ export class Amiable extends GuStack {
     const isProd = stage === "PROD";
 
     const distBucket = GuDistributionBucketParameter.getInstance(this).valueAsString;
-
-    const allowedCIDRs = [
-      GuardianPublicNetworks.London,
-      GuardianPublicNetworks.NewYork1,
-      GuardianPublicNetworks.NewYork2,
-    ];
 
     const ec2App = new GuPlayApp(this, {
       app,
@@ -55,7 +48,7 @@ export class Amiable extends GuStack {
             unhealthyInstancesAlarm: true,
           }
         : { noMonitoring: true },
-      access: { scope: AccessScope.RESTRICTED, cidrRanges: allowedCIDRs.map((cidr) => Peer.ipv4(cidr)) },
+      access: { scope: AccessScope.PUBLIC },
       roleConfiguration: {
         additionalPolicies: [
           new GuSESSenderPolicy(this),

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^2.0.0",
-    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1",
     "@types/jest": "^29.2.2",
     "eslint": "^8.31.0",
     "@types/node": "18.11.18",

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -378,10 +378,6 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.26.0"
 
-"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1":
-  version "1.2.0"
-  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#c4cb5466ab2918448128c8d87b3029e1e77f821c"
-
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"


### PR DESCRIPTION
## What does this change?

This PR updates the load balancer security groups so that requests originating from any ip address is able to reach the load balancer (previously requests were only allowed from some Guardian-specific CIDR ranges). We have discussed this change with InfoSec and they are happy with it.

## How to test

When we're ready, we can test this by deploying to `CODE`.

## How can we measure success?

This PR should allow the department to access/use AMIable again.

## Have we considered potential risks?

Yes, we have put a number of mitigations in place before removing these security group restrictions:

1. We've added Google Auth at the ALB: https://github.com/guardian/amiable/pull/389
2. We now require users to be part of a specific Google Group to login via the Play application: https://github.com/guardian/amiable/pull/390
3. WAF has been enabled (manually via the console)