### PR TITLE
Create SSM parameter with ALB arn (for WAF configuration)

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -92,6 +92,25 @@ exports[`The Amiable stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AlbSsmParam485C1D52": {
+      "Properties": {
+        "DataType": "text",
+        "Description": "The arn of the ALB for amiable-CODE. N.B. this parameter is created via cdk",
+        "Name": "/infosec/waf/services/CODE/amiable-alb-arn",
+        "Tags": {
+          "Stack": "deploy",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/amiable",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Ref": "LoadBalancerAmiable9C4DD4AF",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AmiableCname": {
       "Properties": {
         "Name": "public.amiable.code.dev-gutools.co.uk",
@@ -1063,6 +1082,25 @@ exports[`The Amiable stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
+    "AlbSsmParam485C1D52": {
+      "Properties": {
+        "DataType": "text",
+        "Description": "The arn of the ALB for amiable-PROD. N.B. this parameter is created via cdk",
+        "Name": "/infosec/waf/services/PROD/amiable-alb-arn",
+        "Tags": {
+          "Stack": "deploy",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/amiable",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Ref": "LoadBalancerAmiable9C4DD4AF",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AmiableCname": {
       "Properties": {
         "Name": "public.amiable.gutools.co.uk",

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -9,6 +9,7 @@ import type { App } from "aws-cdk-lib";
 import { Duration, SecretValue } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
 import { ListenerAction, UnauthenticatedAction } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ParameterDataType, ParameterTier, StringParameter } from "aws-cdk-lib/aws-ssm";
 
 interface AmiableProps extends GuStackProps {
   domainName: string;
@@ -77,6 +78,16 @@ export class Amiable extends GuStack {
     });
 
     ec2App.loadBalancer.addSecurityGroup(outboundHttpsSecurityGroup);
+
+    // This parameter is used by https://github.com/guardian/waf
+    new StringParameter(this, "AlbSsmParam", {
+      parameterName: `/infosec/waf/services/${this.stage}/amiable-alb-arn`,
+      description: `The arn of the ALB for amiable-${this.stage}. N.B. this parameter is created via cdk`,
+      simpleName: false,
+      stringValue: ec2App.loadBalancer.loadBalancerArn,
+      tier: ParameterTier.STANDARD,
+      dataType: ParameterDataType.TEXT,
+    });
 
     const clientId = new GuStringParameter(this, "ClientId", {
       description: "Google OAuth client ID",


### PR DESCRIPTION
## What does this change?

This PR adds the ALB's ARN to parameter store so that it can be used/looked up by `cdk` stacks in https://github.com/guardian/waf. 

See https://trello.com/c/Gf4wbq5Y/1716-configure-wafs-for-all-services-in-their-own-repository

Related: https://github.com/guardian/grafana/pull/216

## How to test

[Deploy to `CODE`](https://public.riffraff.gutools.co.uk/deployment/view/5736d9b1-b932-40b1-9903-b8d821b744f2) to confirm that the parameter is created as expected.

## How can we measure success?

This allows us to move forwards with the work to define a separate WAF for AMIgo via a different repository.