### PR TITLE
Create `amaiable.gutools.co.uk`

### DIFF
--- a/cdk/bin/amiable.ts
+++ b/cdk/bin/amiable.ts
@@ -10,13 +10,13 @@ const commonProps = { migratedFromCloudFormation: true, stack: "deploy", env: { 
 export const codeProps = {
   ...commonProps,
   stage: "CODE",
-  domainName: "public.amiable.code.dev-gutools.co.uk",
+  domainName: "amiable.code.dev-gutools.co.uk",
 };
 
 export const prodProps = {
   ...commonProps,
   stage: "PROD",
-  domainName: "public.amiable.gutools.co.uk",
+  domainName: "amiable.gutools.co.uk",
 };
 
 new Amiable(app, "Amiable-CODE", codeProps);

--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -31,6 +31,7 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -267,6 +268,9 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "public.amiable.code.dev-gutools.co.uk",
+        "SubjectAlternativeNames": [
+          "amiable.code.dev-gutools.co.uk",
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -344,6 +348,23 @@ exports[`The Amiable stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": "amiable.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerAmiable9C4DD4AF",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "GetDistributablePolicyAmiableE65882EA": {
       "Properties": {
@@ -616,6 +637,34 @@ exports[`The Amiable stack matches the snapshot 1`] = `
         "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "ListenerAmiableredirectRuleE23C17FD": {
+      "Properties": {
+        "Actions": [
+          {
+            "RedirectConfig": {
+              "Host": "amiable.code.dev-gutools.co.uk",
+              "StatusCode": "HTTP_301",
+            },
+            "Type": "redirect",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "host-header",
+            "HostHeaderConfig": {
+              "Values": [
+                "public.amiable.code.dev-gutools.co.uk",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerAmiable4B1060D6",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "LoadBalancerAmiable9C4DD4AF": {
       "Properties": {
@@ -1021,6 +1070,7 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1257,6 +1307,9 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "public.amiable.gutools.co.uk",
+        "SubjectAlternativeNames": [
+          "amiable.gutools.co.uk",
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -1334,6 +1387,23 @@ exports[`The Amiable stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": "amiable.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerAmiable9C4DD4AF",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "GetDistributablePolicyAmiableE65882EA": {
       "Properties": {
@@ -1708,6 +1778,34 @@ exports[`The Amiable stack matches the snapshot 2`] = `
         "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "ListenerAmiableredirectRuleE23C17FD": {
+      "Properties": {
+        "Actions": [
+          {
+            "RedirectConfig": {
+              "Host": "amiable.gutools.co.uk",
+              "StatusCode": "HTTP_301",
+            },
+            "Type": "redirect",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "host-header",
+            "HostHeaderConfig": {
+              "Values": [
+                "public.amiable.gutools.co.uk",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerAmiable4B1060D6",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "LoadBalancerAmiable9C4DD4AF": {
       "Properties": {


### PR DESCRIPTION
## What does this change?

As part of the work to restore pre-incident URLs, this change creates `amiable.gutools.co.uk`. It is a CNAME to the same ALB hosting `public.amiable.gutools.co.uk`.

The TLS certificate used by the ALB is also changed, adding the new domain as a subject alternative domain.

In order to offer seamless DX, we also configure a 301 redirect from the legacy domain to this new one so that requests always land on `amiable.gutools.co.uk`. This is important because the auth config only supports one domain name.

We will remove the legacy domain in a future change.

The above is repeated for the CODE forms too.

Once merged, AMIable will be accessible via `public.amiable.gutools.co.uk` and `amiable.gutools.co.uk`.

> **Note**
> We'd need to change the [config in S3](https://github.com/guardian/amiable/blob/abc13f135d20b75530f842ad52c90dc75a8feed6/cdk/lib/amiable/amiable.ts#L35) to use `amiable.gutools.co.uk` before shipping this change.
