### PR TITLE
Use the focal-java8 base image for the service AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-focal-java11-deploy-infrastructure
+        Recipe: arm64-focal-java8-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure
+        Recipe: arm64-focal-java11-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-focal-java8-deploy-infrastructure.

This will allow us to:

- Move AMIable to 20.04 to avoid the 18.04 EOL
- Test whether the new `arm64-focal-java8-deploy-infrastructure` image is working as expected

## How to test

Deploy this PR to the CODE environment and check the EC2 instances with the new AMI are successfully brought into service & that we can access the AMIable UI.

## How can we measure success?

Can we use the focal AMI to successfully deploy AMIable?

## Have we considered potential risks?

AMIable is not deployable with Focal base AMIs, we'll revert.