### PR TITLE
chore: Bump @guardian/cdk 49.0.0 -> 49.4.0

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -14,7 +14,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "GuPlayApp",
       "GuCertificate",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -22,8 +21,8 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuStringParameter",
       "GuApplicationTargetGroup",
@@ -115,8 +114,16 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupAmiableLaunchConfig09A6D8E3",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployCODEamiableCD81551B",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployCODEamiableCD81551B",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -144,11 +151,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "amiable/AutoScalingGroupAmiable",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -174,77 +176,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupAmiableInstanceProfile386BEAE5": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleAmiable56110022",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupAmiableLaunchConfig09A6D8E3": {
-      "DependsOn": [
-        "InstanceRoleAmiable56110022",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupAmiableInstanceProfile386BEAE5",
-        },
-        "ImageId": {
-          "Ref": "AMIAmiable",
-        },
-        "InstanceType": "t4g.small",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupAmiable42C3598C",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
-
-          mkdir /amiable
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/CODE/amiable/conf/amiable-service-account-cert.json /amiable/
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/CODE/amiable/conf/amiable.conf /etc/
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/CODE/amiable/amiable.deb /amiable/
-
-          dpkg -i /amiable/amiable.deb",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateAmiable3AC0F81D": {
       "DeletionPolicy": "Retain",
@@ -546,6 +477,20 @@ exports[`The Amiable stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
         "Path": "/",
         "Tags": [
           {
@@ -744,6 +689,27 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerAmiableSecurityGrouptoamiableWazuhSecurityGroup9F0B1D5090007F50784A": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerAmiableSecurityGroupAE4F7AF8",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadAmiable24BF3AAC": {
       "Properties": {
         "PolicyDocument": {
@@ -787,42 +753,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleAmiable56110022",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
         "Roles": [
           {
             "Ref": "InstanceRoleAmiable56110022",
@@ -923,6 +853,202 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "WazuhSecurityGroupfromamiableLoadBalancerAmiableSecurityGroup8E8C95839000B6C591F8": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerAmiableSecurityGroupAE4F7AF8",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromamiableldpaccessAmiable1EDD8FAB900057F6702D": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "ldpaccessAmiable1869C179",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "deployCODEamiableCD81551B": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployCODEamiableProfile73DE6E5D",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIAmiable",
+          },
+          "InstanceType": "t4g.small",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupAmiable42C3598C",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/amiable",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "amiable/deploy-CODE-amiable",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/amiable",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "amiable/deploy-CODE-amiable",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+
+          mkdir /amiable
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/CODE/amiable/conf/amiable-service-account-cert.json /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/CODE/amiable/conf/amiable.conf /etc/
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/CODE/amiable/amiable.deb /amiable/
+
+          dpkg -i /amiable/amiable.deb",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/amiable",
+              },
+              {
+                "Key": "Name",
+                "Value": "amiable/deploy-CODE-amiable",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "CODE",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployCODEamiableProfile73DE6E5D": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleAmiable56110022",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
     "ldpaccessAmiable1869C179": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -984,6 +1110,27 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "ldpaccessAmiabletoamiableWazuhSecurityGroup9F0B1D5090009AC69FD4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "ldpaccessAmiable1869C179",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
   },
 }
 `;
@@ -1002,7 +1149,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "GuPlayApp",
       "GuCertificate",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -1010,8 +1156,8 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuStringParameter",
       "GuApplicationTargetGroup",
@@ -1105,8 +1251,16 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupAmiableLaunchConfig09A6D8E3",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployPRODamiableED398871",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployPRODamiableED398871",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -1134,11 +1288,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "Amiable-PROD/AutoScalingGroupAmiable",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -1164,77 +1313,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupAmiableInstanceProfile386BEAE5": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleAmiable56110022",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupAmiableLaunchConfig09A6D8E3": {
-      "DependsOn": [
-        "InstanceRoleAmiable56110022",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupAmiableInstanceProfile386BEAE5",
-        },
-        "ImageId": {
-          "Ref": "AMIAmiable",
-        },
-        "InstanceType": "t4g.small",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupAmiable42C3598C",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
-
-          mkdir /amiable
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/PROD/amiable/conf/amiable-service-account-cert.json /amiable/
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/PROD/amiable/conf/amiable.conf /etc/
-          aws --region eu-west-1 s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/PROD/amiable/amiable.deb /amiable/
-
-          dpkg -i /amiable/amiable.deb",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateAmiable3AC0F81D": {
       "DeletionPolicy": "Retain",
@@ -1638,6 +1716,20 @@ exports[`The Amiable stack matches the snapshot 2`] = `
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
         "Path": "/",
         "Tags": [
           {
@@ -1836,6 +1928,27 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerAmiableSecurityGrouptoAmiablePRODWazuhSecurityGroupC2FDCB8B9000F7466E51": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerAmiableSecurityGroupAE4F7AF8",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadAmiable24BF3AAC": {
       "Properties": {
         "PolicyDocument": {
@@ -1879,42 +1992,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleAmiable56110022",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
         "Roles": [
           {
             "Ref": "InstanceRoleAmiable56110022",
@@ -2112,6 +2189,202 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "WazuhSecurityGroupfromAmiablePRODLoadBalancerAmiableSecurityGroup7EE4175D9000F748E226": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerAmiableSecurityGroupAE4F7AF8",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromAmiablePRODldpaccessAmiable77AFE83C900058EEED87": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "ldpaccessAmiable1869C179",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "deployPRODamiableED398871": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployPRODamiableProfileF15CA793",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIAmiable",
+          },
+          "InstanceType": "t4g.small",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupAmiable42C3598C",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/amiable",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Amiable-PROD/deploy-PROD-amiable",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/amiable",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Amiable-PROD/deploy-PROD-amiable",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+
+          mkdir /amiable
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/PROD/amiable/conf/amiable-service-account-cert.json /amiable/
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/PROD/amiable/conf/amiable.conf /etc/
+          aws --region eu-west-1 s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/PROD/amiable/amiable.deb /amiable/
+
+          dpkg -i /amiable/amiable.deb",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/amiable",
+              },
+              {
+                "Key": "Name",
+                "Value": "Amiable-PROD/deploy-PROD-amiable",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "PROD",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployPRODamiableProfileF15CA793": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleAmiable56110022",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
     "ldpaccessAmiable1869C179": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -2158,6 +2431,27 @@ exports[`The Amiable stack matches the snapshot 2`] = `
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupAmiable42C3598C",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "ldpaccessAmiable1869C179",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ldpaccessAmiabletoAmiablePRODWazuhSecurityGroupC2FDCB8B9000025FB59D": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
             "GroupId",
           ],
         },

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -15,13 +15,13 @@
         "cdk": "node_modules/.bin/cdk"
       },
       "devDependencies": {
-        "@guardian/cdk": "49.0.0",
+        "@guardian/cdk": "49.4.0",
         "@guardian/eslint-config-typescript": "^3.0.0",
         "@types/jest": "^29.4.0",
         "@types/node": "18.11.18",
-        "aws-cdk": "2.54.0",
-        "aws-cdk-lib": "2.54.0",
-        "constructs": "10.1.187",
+        "aws-cdk": "2.64.0",
+        "aws-cdk-lib": "2.64.0",
+        "constructs": "10.1.246",
         "eslint": "^8.33.0",
         "jest": "^29.4.1",
         "jest-teamcity-reporter": "^0.9.0",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg==",
+      "version": "2.2.84",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.84.tgz",
+      "integrity": "sha512-rpYl0eEswNq9N/U0/2gmHgU7gKgxgF0UgP/k+ySuIWw1ghO9B4aXEmBbIrjmz6jF2BVbeL5tL08AfUxpdX2vLw==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -57,9 +57,9 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ==",
+      "version": "2.0.70",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.70.tgz",
+      "integrity": "sha512-MRiW3unEC4Mnip5vgPPwUqUccphBj68aif/tI0wGjS4yKXo+uJtat9WMAWxGIsaLi+EdGTD2t1YPdTkUmPnBTw==",
       "dev": true
     },
     "node_modules/@babel/code-frame": {
@@ -707,17 +707,17 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "49.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
-      "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
+      "version": "49.4.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
+      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
       "dev": true,
       "dependencies": {
-        "@oclif/core": "1.21.0",
-        "aws-cdk-lib": "2.54.0",
-        "aws-sdk": "^2.1272.0",
+        "@oclif/core": "1.24.2",
+        "aws-cdk-lib": "2.64.0",
+        "aws-sdk": "^2.1315.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.72.0",
-        "constructs": "10.1.187",
+        "codemaker": "^1.75.0",
+        "constructs": "10.1.246",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -730,9 +730,9 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.54.0",
-        "aws-cdk-lib": "2.54.0",
-        "constructs": "10.1.187"
+        "aws-cdk": "2.64.0",
+        "aws-cdk-lib": "2.64.0",
+        "constructs": "10.1.246"
       }
     },
     "node_modules/@guardian/eslint-config": {
@@ -1291,13 +1291,13 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
       "dev": true,
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.3",
+        "@oclif/screen": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
@@ -1361,6 +1361,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
       "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
+      "deprecated": "Deprecated in favor of @oclif/core",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -1952,9 +1953,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
-      "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1967,9 +1968,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
-      "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1983,16 +1984,16 @@
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.16",
+        "@aws-cdk/asset-awscli-v1": "^2.2.52",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -2071,7 +2072,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2125,7 +2126,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2173,9 +2174,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1295.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1295.0.tgz",
-      "integrity": "sha512-HVYoFCyfiL8gzL/c0lSRTg8tWBLfqAEDfwzGe338ww/LahpmC6C07S71SBBIvtGq3dpd7IwEobAbubZDijrA0Q==",
+      "version": "2.1324.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1324.0.tgz",
+      "integrity": "sha512-7T9Jn6qtzCANdqRcdhxZ9Fx31/U+h/VPFxEU3+sFEnC7WtGtRlgmsJOY2lIdFKRXkHYT3Jw5MqDyjnb/i1QqbA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2534,9 +2535,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.3"
@@ -2570,9 +2571,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.73.0.tgz",
-      "integrity": "sha512-pgVFCAbR0Yw/qTrV/W8R7cXWJouhONMRf8sNCjmAGJyV3MFaLN4sUPdUkzYUu7LCkuHPh0nvYRlExWzrkhm7vw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.76.0.tgz",
+      "integrity": "sha512-EqnBOOiEV+kjyRghA5Z0TX22VnVH2Mgo2diOSYelcmntlTSiQkZimGof6jxE5j1buzjEVBK1d1W7bhRKYGegUg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2628,9 +2629,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.187",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
-      "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
+      "version": "10.1.246",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
+      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -3522,9 +3523,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
-      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7223,9 +7224,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg==",
+      "version": "2.2.84",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.84.tgz",
+      "integrity": "sha512-rpYl0eEswNq9N/U0/2gmHgU7gKgxgF0UgP/k+ySuIWw1ghO9B4aXEmBbIrjmz6jF2BVbeL5tL08AfUxpdX2vLw==",
       "dev": true
     },
     "@aws-cdk/asset-kubectl-v20": {
@@ -7235,9 +7236,9 @@
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ==",
+      "version": "2.0.70",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.70.tgz",
+      "integrity": "sha512-MRiW3unEC4Mnip5vgPPwUqUccphBj68aif/tI0wGjS4yKXo+uJtat9WMAWxGIsaLi+EdGTD2t1YPdTkUmPnBTw==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -7734,17 +7735,17 @@
       }
     },
     "@guardian/cdk": {
-      "version": "49.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
-      "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
+      "version": "49.4.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
+      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
       "dev": true,
       "requires": {
-        "@oclif/core": "1.21.0",
-        "aws-cdk-lib": "2.54.0",
-        "aws-sdk": "^2.1272.0",
+        "@oclif/core": "1.24.2",
+        "aws-cdk-lib": "2.64.0",
+        "aws-sdk": "^2.1315.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.72.0",
-        "constructs": "10.1.187",
+        "codemaker": "^1.75.0",
+        "constructs": "10.1.246",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -8184,13 +8185,13 @@
       }
     },
     "@oclif/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.3",
+        "@oclif/screen": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
@@ -8686,30 +8687,30 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
-      "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
-      "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.16",
+        "@aws-cdk/asset-awscli-v1": "^2.2.52",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -8765,7 +8766,7 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.2.4",
           "bundled": true,
           "dev": true
         },
@@ -8800,7 +8801,7 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
@@ -8830,9 +8831,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1295.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1295.0.tgz",
-      "integrity": "sha512-HVYoFCyfiL8gzL/c0lSRTg8tWBLfqAEDfwzGe338ww/LahpmC6C07S71SBBIvtGq3dpd7IwEobAbubZDijrA0Q==",
+      "version": "2.1324.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1324.0.tgz",
+      "integrity": "sha512-7T9Jn6qtzCANdqRcdhxZ9Fx31/U+h/VPFxEU3+sFEnC7WtGtRlgmsJOY2lIdFKRXkHYT3Jw5MqDyjnb/i1QqbA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9081,9 +9082,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.3"
@@ -9107,9 +9108,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.73.0.tgz",
-      "integrity": "sha512-pgVFCAbR0Yw/qTrV/W8R7cXWJouhONMRf8sNCjmAGJyV3MFaLN4sUPdUkzYUu7LCkuHPh0nvYRlExWzrkhm7vw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.76.0.tgz",
+      "integrity": "sha512-EqnBOOiEV+kjyRghA5Z0TX22VnVH2Mgo2diOSYelcmntlTSiQkZimGof6jxE5j1buzjEVBK1d1W7bhRKYGegUg==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -9158,9 +9159,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.187",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
-      "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
+      "version": "10.1.246",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
+      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
       "dev": true
     },
     "convert-source-map": {
@@ -9842,9 +9843,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
-          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -27,10 +27,10 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5",
-    "@guardian/cdk": "49.0.0",
-    "aws-cdk": "2.54.0",
-    "aws-cdk-lib": "2.54.0",
-    "constructs": "10.1.187"
+    "@guardian/cdk": "49.4.0",
+    "aws-cdk": "2.64.0",
+    "aws-cdk-lib": "2.64.0",
+    "constructs": "10.1.246"
   },
   "dependencies": {
     "source-map-support": "^0.5.16"


### PR DESCRIPTION
## What does this change?

Update GuCDK to https://github.com/guardian/cdk/releases/tag/v49.4.0. This has been tested in cdk-playground as part of the PR review process, but updating AMIable to exercise this change on a real repository to get some immediate feddback before others start using it.

## How to test

Deploy in CODE, ensure deployment is successful and that the UI is reachable. Review EC2 instance configuration in the AWS console to ensure it matches expectations (tags, SGs etc).

## How can we measure success?

Testing is successful, this change is deployed to PROD.

## Have we considered potential risks?

Deployment fails for some reason associated with the GuCDK release, rollback and remediate in https://github.com/guardian/cdk repostory.