### PR TITLE
Test focal image with updated cdk-base recipe from amigo code

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,8 +15,8 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-focal-java8-deploy-infrastructure
-        AmigoStage: PROD
+        Recipe: arm64-bionic-java8-deploy-infrastructure
+        AmigoStage: CODE
         BuiltBy: amigo
       amiEncrypted: true
       templateStagePaths:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-bionic-java8-deploy-infrastructure
+        Recipe: arm64-focal-java11-deploy-infrastructure
         AmigoStage: CODE
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Testing https://amigo.code.dev-gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure/bakes/1

This bake uses the updated AMIgo CODE recipe for cdk-base:

https://github.com/guardian/amigo/pull/1066

Deployed, not yet tested ❓ : https://riffraff.gutools.co.uk/deployment/view/7a1ff8bd-eb66-48c7-a339-5c1134545611