### PR TITLE
Test bionic image with updated cdk-base recipe from amigo code

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,8 +15,8 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-focal-java8-deploy-infrastructure
-        AmigoStage: PROD
+        Recipe: arm64-bionic-java8-deploy-infrastructure
+        AmigoStage: CODE
         BuiltBy: amigo
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
## What does this change?

Testing https://amigo.code.dev-gutools.co.uk/recipes/arm64-bionic-java8-deploy-infrastructure/bakes/12

This bake uses the updated AMIgo CODE recipe for cdk-base:

https://github.com/guardian/amigo/pull/1066

Deployed and tested: https://riffraff.gutools.co.uk/deployment/view/c3a1e904-55e0-415d-8294-0724b04c5fb0 ✅ 

**Note:** @jacobwinch had already put together a convenient change for this - I rebaked after updating AMIgo.