### PR TITLE
build using actions riff-raff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,17 @@ jobs:
           LAST_TEAMCITY_BUILD=1007
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           ./script/ci
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: amiable
+          buildNumberOffset: 1007
+          buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
+          projectName: tools::amiable
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            cloudformation:
+              - cdk/cdk.out
+            amiable:
+              - amiable.deb

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := """amiable"""
 
 version := "1.0-SNAPSHOT"
 
-enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
+enablePlugins(PlayScala, JDebPackaging, SystemdPlugin)
 
 scalaVersion := "2.13.10"
 
@@ -84,11 +84,3 @@ packageSummary := "AMIable"
 packageDescription := """Web app for monitoring the use of AMIs"""
 debianPackageDependencies := Seq("openjdk-8-jre-headless")
 
-riffRaffPackageType := (Debian / packageBin).value
-riffRaffArtifactResources := Seq(
-  riffRaffPackageType.value -> s"${name.value}/${name.value}.deb",
-  baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
-  baseDirectory.value / "cdk/cdk.out/Amiable-CODE.template.json" -> "cloudformation/Amiable-CODE.template.json",
-  baseDirectory.value / "cdk/cdk.out/Amiable-PROD.template.json" -> "cloudformation/Amiable-PROD.template.json"
-)
-riffRaffManifestProjectName:= s"tools::${name.value}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 addSbtPlugin(
   "com.github.sbt" % "sbt-native-packager" % "1.9.16"
 ) // scala-steward:off
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact(
   "jdeb",
   "jar",

--- a/script/ci
+++ b/script/ci
@@ -9,4 +9,5 @@ set -e
 )
 
 
-sbt clean scalafmtCheckAll compile test riffRaffUpload
+sbt clean scalafmtCheckAll compile test debian:packageBin
+mv target/*.deb ./amiable.deb


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

amiable no longer builds using sbt-riffraff-artifact, instead preferring actions-riff-raff

## How to test

verify that you are able to build and deploy to code using this branch

## How can we measure success?

number of vulnerabilities decreases as a result of the migration
