### PR TITLE
build using java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v3.11.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'corretto'
           cache: 'sbt'
 
       # See https://github.com/github/scripts-to-rule-them-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/setup-node@v3.6.0
 
       # See https://github.com/actions/setup-java
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'adopt'
           cache: 'sbt'
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

A bunch of dependency upgrades will not compile until this project is built using java 11

## How to test

Verify the project builds

## How can we measure success?

Dependency bumps can resume
