### PR TITLE
Additional changes for Java 11 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,7 @@ Universal / javaOptions ++= Seq(
   "-J-XX:MaxRAMFraction=2",
   "-J-XX:InitialRAMFraction=2",
   "-J-XX:MaxMetaspaceSize=300m",
-  "-J-XX:+PrintGCDetails",
-  "-J-XX:+PrintGCDateStamps",
+  "-J-Xlog:gc*",
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,4 +82,4 @@ Universal / packageName := name.value
 maintainer := "Guardian Developers <dig.dev.software@theguardian.com>"
 packageSummary := "AMIable"
 packageDescription := """Web app for monitoring the use of AMIs"""
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
+debianPackageDependencies := Seq("java-11-amazon-corretto-jdk:arm64")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiParameter: AMIAmiable
       amiTags:
-        Recipe: arm64-focal-java8-deploy-infrastructure
+        Recipe: arm64-focal-java11-deploy-infrastructure
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

This PR is a follow-up to https://github.com/guardian/amiable/pull/514, which led to some deployment problems (see [failed deployment](https://riffraff.gutools.co.uk/deployment/view/2667f990-efcf-4c0a-9866-64b38d9dad7b) and [errors in application logs](https://logs.gutools.co.uk/s/devx/goto/e834e8e0-f8a4-11ed-b159-5f35e3cb16f1)). There are more details on these additional changes in this [guide](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit#heading=h.3tqy5rhbhd23).

## How to test

I've tested this by confirming that a [`CODE` deployment now works as expected](https://riffraff.gutools.co.uk/deployment/view/e2e52951-d479-4a0d-9686-6b477fc4f8c4).

## How can we measure success?

This should fix deployments of `main`.

## Have we considered potential risks?

It's possible that this upgrade will cause some other more subtle problems, but we haven't had many problems when upgrading other DevX apps, so I think this is pretty low risk given the nature of this application.