### PR TITLE
chore(deps): Bump various dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val akkaSerializationJacksonOverrides = Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala"
 ).map(_ % jacksonVersion)
 
-val awsSdkVersion = "1.12.458"
+val awsSdkVersion = "1.12.473"
 
 libraryDependencies ++= Seq(
   jdbc,

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ libraryDependencies ++= Seq(
   "org.quartz-scheduler" % "quartz" % "2.3.2",
   "com.typesafe.play" %% "play-json-joda" % "2.10.0-RC8",
   specs2 % Test,
-  "org.scalatest" %% "scalatest" % "3.2.15" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.16" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
   "org.mockito" % "mockito-core" % "4.9.0" % Test,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3"

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ libraryDependencies ++= Seq(
   "com.google.code.gson" % "gson" % "2.10.1",
   "com.gu.play-googleauth" % "play-v28_2.13" % "2.2.7",
   "org.quartz-scheduler" % "quartz" % "2.3.2",
-  "com.typesafe.play" %% "play-json-joda" % "2.10.0-RC7",
+  "com.typesafe.play" %% "play-json-joda" % "2.10.0-RC8",
   specs2 % Test,
   "org.scalatest" %% "scalatest" % "3.2.15" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ libraryDependencies ++= Seq(
   specs2 % Test,
   "org.scalatest" %% "scalatest" % "3.2.16" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "4.9.0" % Test,
+  "org.mockito" % "mockito-core" % "5.3.1" % Test,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
 ) ++ jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ scalacOptions := Seq(
 )
 
 // https://github.com/orgs/playframework/discussions/11222
-val jacksonVersion = "2.15.0"
-val jacksonDatabindVersion = "2.15.0"
+val jacksonVersion = "2.15.1"
+val jacksonDatabindVersion = "2.15.1"
 
 val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-core",

--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
-  testResultsProcessor: "jest-teamcity-reporter",
   transformIgnorePatterns: ["node_modules/(?!@guardian/private-infrastructure-config)"],
   setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -15,13 +15,13 @@
         "cdk": "node_modules/.bin/cdk"
       },
       "devDependencies": {
-        "@guardian/cdk": "49.4.0",
+        "@guardian/cdk": "50.5.0",
         "@guardian/eslint-config-typescript": "^5.0.0",
         "@types/jest": "^29.5.1",
         "@types/node": "18.16.3",
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246",
+        "aws-cdk": "2.77.0",
+        "aws-cdk-lib": "2.77.0",
+        "constructs": "10.2.8",
         "eslint": "^8.39.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.8",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.84",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.84.tgz",
-      "integrity": "sha512-rpYl0eEswNq9N/U0/2gmHgU7gKgxgF0UgP/k+ySuIWw1ghO9B4aXEmBbIrjmz6jF2BVbeL5tL08AfUxpdX2vLw==",
+      "version": "2.2.183",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.183.tgz",
+      "integrity": "sha512-D+E0drcgCjDn43GjsATIpkMeZlFoQFmf86GSlIF0AtNyl0IVrNKsKs/7J4oESrCTTCLL/x9vS7mG9e1ZrKbLpw==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -56,9 +56,9 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.70",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.70.tgz",
-      "integrity": "sha512-MRiW3unEC4Mnip5vgPPwUqUccphBj68aif/tI0wGjS4yKXo+uJtat9WMAWxGIsaLi+EdGTD2t1YPdTkUmPnBTw==",
+      "version": "2.0.153",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.153.tgz",
+      "integrity": "sha512-EL2XCW6C3szBPHI4XWQsb68pqc719nR+8sfsEhyjzBNn0idgZg2ViujI3/1/jWnJwHPnvMOKQcmr/bOKzCPAgA==",
       "dev": true
     },
     "node_modules/@babel/code-frame": {
@@ -739,17 +739,17 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "49.4.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+      "version": "50.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.5.0.tgz",
+      "integrity": "sha512-/nxwIRsXyIBKhQHUl8LCofetJjBiQGyX2rh7zPtnzW4lyebBjG4AJ1OrBm5TSe6OxVupS7q+WqesqFIJ3C1mIQ==",
       "dev": true,
       "dependencies": {
-        "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.64.0",
-        "aws-sdk": "^2.1315.0",
+        "@oclif/core": "2.8.2",
+        "aws-cdk-lib": "2.77.0",
+        "aws-sdk": "^2.1365.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.75.0",
-        "constructs": "10.1.246",
+        "codemaker": "^1.80.0",
+        "constructs": "10.2.8",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -762,9 +762,9 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246"
+        "aws-cdk": "2.77.0",
+        "aws-cdk-lib": "2.77.0",
+        "constructs": "10.2.8"
       }
     },
     "node_modules/@guardian/eslint-config": {
@@ -1311,21 +1311,20 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
-      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-g50NrCdEcFlBfuwZb9RxLmxPNQ9wIaBPOiwbxlGYRkHMnsC6LNHcvVtyDnmndU8qoXrmCOZ6ocSZenOMlG+G1w==",
       "dev": true,
       "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -1341,8 +1340,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
@@ -1369,22 +1370,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
-      "dev": true
-    },
-    "node_modules/@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "deprecated": "Deprecated in favor of @oclif/core",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@pkgr/utils": {
@@ -1494,6 +1479,15 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1973,9 +1967,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+      "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1988,9 +1982,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+      "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2000,13 +1994,14 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -2015,6 +2010,7 @@
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
         "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -2029,6 +2025,55 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2064,8 +2109,38 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -2100,6 +2175,21 @@
         "node": ">= 4"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
       "dev": true,
@@ -2120,6 +2210,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2154,6 +2250,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.3.8",
       "dev": true,
@@ -2169,6 +2274,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "dev": true,
@@ -2176,6 +2340,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -2194,9 +2367,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1354.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1354.0.tgz",
-      "integrity": "sha512-3aDxvyuOqMB9DqJguCq6p8momdsz0JR1axwkWOOCzHA7a35+Bw+WLmqt3pWwRjR1tGIwkkZ2CvGJObYHsOuw3w==",
+      "version": "2.1383.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1383.0.tgz",
+      "integrity": "sha512-A8sdfcrlGYXqu5x8dpwh1lg9/o354leCx08N/irwH3U4sAwQin0vHsI9DHmaJ0PLNo/TuzeLE3s4dLpI3mWtww==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2591,9 +2764,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.76.0.tgz",
-      "integrity": "sha512-EqnBOOiEV+kjyRghA5Z0TX22VnVH2Mgo2diOSYelcmntlTSiQkZimGof6jxE5j1buzjEVBK1d1W7bhRKYGegUg==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.82.0.tgz",
+      "integrity": "sha512-urr9UZD4HvuKj0fKZg480N5+TtSk2LNX5Dw7e/mOCOtSWxrUBlGN10s+AucBigUMX2ROUIJmbflIIXALs7ZS7Q==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2649,9 +2822,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.246",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.8.tgz",
+      "integrity": "sha512-3Dr4htAd64LRn6+ts5cDm1ZijE/2rDJnaPRD9FQi3CGTfZIm0nA9ZzJDOEwBRFfU8A6wmQvZ3B56p4XLM6B4hg==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -2810,9 +2983,9 @@
       }
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -4560,15 +4733,15 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.6.tgz",
+      "integrity": "sha512-G43Ub9IYEFfu72sua6rzooi8V8Gz2lkfk48rW20vEWCGizeaEPlKB1Kh8JIA84yQbiAEfqlPmSpGgCKKxH3rDA==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -6829,9 +7002,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -7129,6 +7302,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7263,9 +7442,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.84",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.84.tgz",
-      "integrity": "sha512-rpYl0eEswNq9N/U0/2gmHgU7gKgxgF0UgP/k+ySuIWw1ghO9B4aXEmBbIrjmz6jF2BVbeL5tL08AfUxpdX2vLw==",
+      "version": "2.2.183",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.183.tgz",
+      "integrity": "sha512-D+E0drcgCjDn43GjsATIpkMeZlFoQFmf86GSlIF0AtNyl0IVrNKsKs/7J4oESrCTTCLL/x9vS7mG9e1ZrKbLpw==",
       "dev": true
     },
     "@aws-cdk/asset-kubectl-v20": {
@@ -7275,9 +7454,9 @@
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.70",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.70.tgz",
-      "integrity": "sha512-MRiW3unEC4Mnip5vgPPwUqUccphBj68aif/tI0wGjS4yKXo+uJtat9WMAWxGIsaLi+EdGTD2t1YPdTkUmPnBTw==",
+      "version": "2.0.153",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.153.tgz",
+      "integrity": "sha512-EL2XCW6C3szBPHI4XWQsb68pqc719nR+8sfsEhyjzBNn0idgZg2ViujI3/1/jWnJwHPnvMOKQcmr/bOKzCPAgA==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -7795,17 +7974,17 @@
       "dev": true
     },
     "@guardian/cdk": {
-      "version": "49.4.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+      "version": "50.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.5.0.tgz",
+      "integrity": "sha512-/nxwIRsXyIBKhQHUl8LCofetJjBiQGyX2rh7zPtnzW4lyebBjG4AJ1OrBm5TSe6OxVupS7q+WqesqFIJ3C1mIQ==",
       "dev": true,
       "requires": {
-        "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.64.0",
-        "aws-sdk": "^2.1315.0",
+        "@oclif/core": "2.8.2",
+        "aws-cdk-lib": "2.77.0",
+        "aws-sdk": "^2.1365.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.75.0",
-        "constructs": "10.1.246",
+        "codemaker": "^1.80.0",
+        "constructs": "10.2.8",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -8236,21 +8415,20 @@
       }
     },
     "@oclif/core": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
-      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-g50NrCdEcFlBfuwZb9RxLmxPNQ9wIaBPOiwbxlGYRkHMnsC6LNHcvVtyDnmndU8qoXrmCOZ6ocSZenOMlG+G1w==",
       "dev": true,
       "requires": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -8266,8 +8444,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
@@ -8291,18 +8471,6 @@
           }
         }
       }
-    },
-    "@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
-      "dev": true
-    },
-    "@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "dev": true
     },
     "@pkgr/utils": {
       "version": "2.3.1",
@@ -8405,6 +8573,15 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/cli-progress": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
@@ -8738,23 +8915,23 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+      "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+      "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -8763,11 +8940,41 @@
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
         "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -8795,8 +9002,31 @@
           "bundled": true,
           "dev": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
         "concat-map": {
           "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
           "bundled": true,
           "dev": true
         },
@@ -8821,6 +9051,16 @@
           "bundled": true,
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "jsonfile": {
           "version": "6.1.0",
           "bundled": true,
@@ -8832,6 +9072,11 @@
         },
         "jsonschema": {
           "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.truncate": {
+          "version": "4.4.2",
           "bundled": true,
           "dev": true
         },
@@ -8856,6 +9101,11 @@
           "bundled": true,
           "dev": true
         },
+        "require-from-string": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
         "semver": {
           "version": "7.3.8",
           "bundled": true,
@@ -8864,10 +9114,58 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "universalify": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         },
         "yallist": {
           "version": "4.0.0",
@@ -8882,9 +9180,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1354.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1354.0.tgz",
-      "integrity": "sha512-3aDxvyuOqMB9DqJguCq6p8momdsz0JR1axwkWOOCzHA7a35+Bw+WLmqt3pWwRjR1tGIwkkZ2CvGJObYHsOuw3w==",
+      "version": "2.1383.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1383.0.tgz",
+      "integrity": "sha512-A8sdfcrlGYXqu5x8dpwh1lg9/o354leCx08N/irwH3U4sAwQin0vHsI9DHmaJ0PLNo/TuzeLE3s4dLpI3mWtww==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9159,9 +9457,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.76.0.tgz",
-      "integrity": "sha512-EqnBOOiEV+kjyRghA5Z0TX22VnVH2Mgo2diOSYelcmntlTSiQkZimGof6jxE5j1buzjEVBK1d1W7bhRKYGegUg==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.82.0.tgz",
+      "integrity": "sha512-urr9UZD4HvuKj0fKZg480N5+TtSk2LNX5Dw7e/mOCOtSWxrUBlGN10s+AucBigUMX2ROUIJmbflIIXALs7ZS7Q==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -9210,9 +9508,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.246",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.8.tgz",
+      "integrity": "sha512-3Dr4htAd64LRn6+ts5cDm1ZijE/2rDJnaPRD9FQi3CGTfZIm0nA9ZzJDOEwBRFfU8A6wmQvZ3B56p4XLM6B4hg==",
       "dev": true
     },
     "convert-source-map": {
@@ -9324,9 +9622,9 @@
       }
     },
     "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
@@ -10615,15 +10913,15 @@
       }
     },
     "jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.6.tgz",
+      "integrity": "sha512-G43Ub9IYEFfu72sua6rzooi8V8Gz2lkfk48rW20vEWCGizeaEPlKB1Kh8JIA84yQbiAEfqlPmSpGgCKKxH3rDA==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       }
     },
     "jest": {
@@ -12295,9 +12593,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
       "dev": true
     },
     "tsutils": {
@@ -12522,6 +12820,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wrap-ansi": {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -24,7 +24,6 @@
         "constructs": "10.1.246",
         "eslint": "^8.39.0",
         "jest": "^29.5.0",
-        "jest-teamcity-reporter": "^0.9.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
@@ -5050,12 +5049,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-teamcity-reporter": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/jest-teamcity-reporter/-/jest-teamcity-reporter-0.9.0.tgz",
-      "integrity": "sha512-q6W+ZaJSCIXmxC9wsY67zNn+vwG/EgKJygYJYH860jih5zS6mc2ZFc4v78gh6rgzgM9/siUtQm7SnRunYuWmVw==",
-      "dev": true
     },
     "node_modules/jest-util": {
       "version": "29.5.0",
@@ -10998,12 +10991,6 @@
         "pretty-format": "^29.5.0",
         "semver": "^7.3.5"
       }
-    },
-    "jest-teamcity-reporter": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/jest-teamcity-reporter/-/jest-teamcity-reporter-0.9.0.tgz",
-      "integrity": "sha512-q6W+ZaJSCIXmxC9wsY67zNn+vwG/EgKJygYJYH860jih5zS6mc2ZFc4v78gh6rgzgM9/siUtQm7SnRunYuWmVw==",
-      "dev": true
     },
     "jest-util": {
       "version": "29.5.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -26,10 +26,10 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5",
-    "@guardian/cdk": "49.4.0",
-    "aws-cdk": "2.64.0",
-    "aws-cdk-lib": "2.64.0",
-    "constructs": "10.1.246"
+    "@guardian/cdk": "50.5.0",
+    "aws-cdk": "2.77.0",
+    "aws-cdk-lib": "2.77.0",
+    "constructs": "10.2.8"
   },
   "dependencies": {
     "source-map-support": "^0.5.16"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,7 +22,6 @@
     "eslint": "^8.39.0",
     "@types/node": "18.16.3",
     "jest": "^29.5.0",
-    "jest-teamcity-reporter": "^0.9.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3

--- a/script/ci
+++ b/script/ci
@@ -2,7 +2,6 @@
 
 set -e
 
-# must be done first as sbt uses the CFN template that is generated
 (
  cd cdk
  ./script/ci


### PR DESCRIPTION
## What does this change?
Manually bumps various dependencies whilst our Scala Steward integration appears to be a little broken. Hoping this'll reduce the noise created by https://github.com/guardian/actions-prnouncer 🤞🏽.

| Ecosystem | Module                 | From       | To         |
|-----------|------------------------|------------|------------|
| Node      | jest-teamcity-reporter | 0.9.0      | REMOVED[^1]    |
| Node      | @guardian/cdk          | 49.4.0     | 50.5.0     |
| Node      | aws-cdk                | 2.64.0     | 2.77.0     |
| Node      | aws-cdk-lib            | 2.64.0     | 2.77.0     |
| Node      | constructs             | 10.1.246   | 10.2.8     |
| SBT       | Jackson                | 2.15.0     | 2.15.1     |
| SBT       | AWS SDK                | 1.12.458   | 1.12.473   |
| SBT       | play-json-joda         | 2.10.0-RC7 | 2.10.0-RC8 |
| SBT       | scalatest              | 3.2.15     | 3.2.16     |
| SBT       | mockito-core           | 4.9.0      | 5.3.1      |
| SBT       | sbt           | 1.8.2      | 1.8.3      |

## How to test
This app doesn't do too much, so to test:
- [Deploy to CODE](https://riffraff.gutools.co.uk/deployment/view/9535fbd2-d7d6-485d-a641-2dc2b444ee73)
- Does the app still launch?

[^1]: Not needed since #479.

---
Closes #517.
Closes #512.
Closes #511.
Closes #510.
Closes #509.
Closes #506.
Closes #505.