### PR TITLE
fix: Explicitly list permissions in GitHub workflow

### DIFF
--- a/.github/workflows/tracking-branch.yml
+++ b/.github/workflows/tracking-branch.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update-dependency-update-branch:
+    permissions:
+      id-token: write
+      contents: write
     name: Keep tracking branch up to date with main
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1
     with:


### PR DESCRIPTION
Applies the fix from https://github.com/guardian/riff-raff/pull/1160 to the Scala Steward workflow.

It seems that the org now defaults to "restricted" permissions, where it was previously "permissive". See https://docs.github.com/en/enterprise-server@3.5/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token.

This follows on from https://github.com/guardian/amiable/pull/518 which manually applied updates that Scala Steward was failing to.