### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     labels:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reduces frequency of dependency bumps as they are quite noisy. Amiable is in maintenance mode and will be deprecated soon, so version bumps are not a priority unless they are security-related.


## How can we measure success?

Less noise

## Have we considered potential risks?

We have other mitigations in place to alert us if we need to urgently patch a version for security reasons (snyk/dependabot)
