### PR TITLE
send email for giant instances with old ami

### DIFF
--- a/app/services/notification/ScheduledNotificationRunner.scala
+++ b/app/services/notification/ScheduledNotificationRunner.scala
@@ -21,9 +21,13 @@ class ScheduledNotificationRunner @Inject() (
   def run(today: DateTime): Attempt[List[String]] = {
     for {
       instancesWithAmis <- Prism.instancesWithAmis(SSAA(stage = Some("PROD")))
-      oldInstances = PrismLogic.oldInstances(instancesWithAmis)
+      giantInstances <- Prism.instancesWithAmis(
+        SSAA(stage = Some("rex"), stack = Some("pfi-giant"))
+      )
+      allProdInstancesWithAmis = instancesWithAmis ++ giantInstances
+      oldInstances = PrismLogic.oldInstances(allProdInstancesWithAmis)
       instanceAmiMap = ScheduledNotificationRunner.makeInstanceAmiMap(
-        instancesWithAmis
+        allProdInstancesWithAmis
       )
       ownersWithDefault <- Prism.getOwners
       ownersAndOldInstances = ScheduledNotificationRunner.findInstanceOwners(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
In investigations account, for one of our services Giant, we are not following the same pattern for stage & stack & app as it's done for all other instances. 

For Giant, the pattern is: 
- Stage: `rex`
- Stack: `pfi-playground` | `pfi-giant`
- App: `pfi` | `pfi-worker` | `elasticsearch` | `neo4j`

because of this, we are not receiving email notifications for giant instances with old ami. 
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
