### PR TITLE
Automatically determine obsolete Ubuntu distros

### DIFF
--- a/app/views/fragments/amiOverlay.scala.html
+++ b/app/views/fragments/amiOverlay.scala.html
@@ -1,4 +1,5 @@
 @import config.AMIableConfig
+@import org.joda.time.DateTime
 @(ami: AMI, conf: AMIableConfig ,instanceCount: Option[Int] = None, id: String = java.util.UUID.randomUUID.toString, stackStageApp: Option[SSAA] = None)
 
 @import utils.DateUtils.{getAgeColour, daysAgo}
@@ -35,7 +36,7 @@
         </div>
         <div class="ami-badge__icon-container">
             <a class="modal-trigger black-text" href="#modal-@id">
-                @if(Recommendations.isObsoleteUbuntu(ami)) {
+                @if(Recommendations.isObsoleteUbuntu(ami, DateTime.now())) {
                     <img src="/assets/images/upgrade-icons/dist-eol.png" class="ami-badge__icon" />
                 } else {
                     @ami.upgrade.map { upgrade =>

--- a/app/views/fragments/amiWithUpgrade.scala.html
+++ b/app/views/fragments/amiWithUpgrade.scala.html
@@ -1,4 +1,5 @@
 @import config.AMIableConfig
+@import org.joda.time.DateTime
 @(ami: AMI, conf: AMIableConfig)
 
 @import utils.DateUtils.{getAgeColour}
@@ -9,7 +10,7 @@
     <div class="ami-details--this-ami">
         @amiDetails(ami, conf)
     </div>
-    @if(Recommendations.isObsoleteUbuntu(ami)) {
+    @if(Recommendations.isObsoleteUbuntu(ami, DateTime.now())) {
         <div class="ami-details--upgrade upgrade-image no-upgrade-image dist-eol">
             <div class="no-ami-upgrade--message">This version of Ubuntu is End of Life, you should upgrade.</div>
         </div>


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Replaces hard-coded list of supported Ubuntu versions with logic to work this out, based on the current date. This is done using canonical's appraoch, which is that LTS releases are April in even numbered years, with 5 year support. All other releases have just 9 months support.

We change the logic itself, update the wiring in the template, and add a few more tests for the date logic.

Getting the current date from the template (to pass to the helper function) is not a great pattern, but this is consistent with the current approach in these templates.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've added tests, and we can glance at the UI to make sure that it is correctly identifying obsolete images, if any exist.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

It should be clearer that teams need to update their base image when it drops off support.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

If canonical ever change their approach, this logic will no longer be accurate. This hasn't happened yet, and likely Amiable won't be in use if that comes up.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->