### PR TITLE
remove nvm from cdk ci script

### DIFF
--- a/cdk/script/ci
+++ b/cdk/script/ci
@@ -2,23 +2,6 @@
 
 set -e
 
-nvm_available() {
-  type -t nvm > /dev/null
-}
-
-source_nvm() {
-  if ! nvm_available; then
-    [ -e "/usr/local/opt/nvm/nvm.sh" ] && source /usr/local/opt/nvm/nvm.sh
-  fi
-  if ! nvm_available; then
-    [ -e "$HOME/.nvm/nvm.sh" ] && source "$HOME/.nvm/nvm.sh"
-  fi
-}
-
-source_nvm
-nvm install
-nvm use
-
 npm i
 npm test
 npm run build


### PR DESCRIPTION
# What does this change?

While debugging a failed version bump we discovered that nvm appears to no longer be available on the Github runner. This meant that CI was broken.

## How to test

CI should pass.