### PR TITLE
Ensure sbt is properly installed in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'cdk/package-lock.json'
 
-      # See https://github.com/actions/setup-java
-      - name: Setup Java 11
-        uses: actions/setup-java@v4.5.0
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
+      # See https://github.com/guardian/setup-java
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
 
       - run: |
           LAST_TEAMCITY_BUILD=1007

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -12,15 +12,11 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+
+      # See https://github.com/guardian/setup-java
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
+
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
## What does this change?

Using the Guardian-provided [setup-scala](https://github.com/guardian/setup-scala) workflow allows us to configure and install Java and sbt at the same time. It takes the Java version out of the .tool-versions file, so this file is also added with a (currently) up-to-date Java version.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We should see the workflows complete successfully now.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We'll avoid these workflows breaking when GitHub starts to roll-out the new base image from 5th Dec.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

We're specifying a needlessly specific Java version in the .tool-versions file, to appease `asdf`. We will separately migrate to just the major version by adopting [mise](https://mise.jdx.dev/), but this is something to change globally when we are ready.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

