### PR TITLE
fix: remove sbt-sassify plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
-libraryDependencies += "org.vafer" % "jdeb" % "1.13" artifacts (Artifact(
+libraryDependencies += "org.vafer" % "jdeb" % "1.13" artifacts Artifact(
   "jdeb",
   "jar",
   "jar"
-))
+)
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
@@ -20,5 +20,3 @@ addSbtPlugin("com.github.sbt" % "sbt-jshint" % "2.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-rjs" % "2.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.1.0")
-
-addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")

--- a/sbt
+++ b/sbt
@@ -12,6 +12,6 @@ do
 done
 
 java $DEBUG_PARAMS \
-    -Xms1024M -Xmx2048M -Xss1M -XX:+CMSClassUnloadingEnabled \
+    -Xms1024M -Xmx2048M -Xss1M \
     -Dconfig.file=$HOME/.gu/amiable.local.conf \
     -jar sbt-launch.jar "$@"


### PR DESCRIPTION
## What does this change?
The [sbt-sassify](https://github.com/irundaia/sbt-sassify) plugin depends on [a version of sbt-web](https://repo1.maven.org/maven2/com/typesafe/sbt/sbt-web_2.12_1.0/1.4.4/sbt-web-1.4.4.pom) that is no longer resolvable, for some reason, causing this [CI failure](https://github.com/guardian/amiable/actions/runs/14304284731/job/40084585172#step:6:409).
As far as I can tell, this plugin isn't actually being used anyway so I've removed it.

## How to test
I've [deployed this branch to Code](https://riffraff.gutools.co.uk/deployment/view/f846bd27-b2ca-43ae-83fe-34bd9b842e53) and as far as I can see the pages are all loading properly and there are no visible problems or new log errors or browser console errors or resources failing to load.
