### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @guardian/devx-reliability-and-ops
-* @guardian/devx-security
+* @guardian/devx-reliability-and-ops @guardian/devx-security


### PR DESCRIPTION
If a file group is repeated, only the last line applies.  So in this case, only the security team were notified of a PR.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax.
