### PR TITLE
fix: Exclude htmlunit dependency to resolve security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,12 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.5.18"
 ) ++ jacksonOverrides
 
+// See https://github.com/guardian/amiable/security/dependabot/35
+excludeDependencies += ExclusionRule(
+  organization = "net.sourceforge.htmlunit",
+  name = "htmlunit"
+)
+
 PlayKeys.playDefaultPort := 9101
 
 Universal / packageName := name.value


### PR DESCRIPTION
## What is the purpose of this change?
Excludes a transitive test dependency that we don't currently use.

## What is the value of this change and how do we measure success?
Resolves a critical vulnerability alert: https://github.com/guardian/amiable/security/dependabot/35