### PR TITLE
Switch off access logging feature

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The Amiable stack matches the snapshot 1`] = `
 {
@@ -23,7 +23,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
-      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuHttpsEgressSecurityGroup",
@@ -47,11 +46,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
     "AMIAmiable": {
       "Description": "Amazon Machine Image ID for the app amiable. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
-    },
-    "AccessLoggingBucket": {
-      "Default": "/account/services/access-logging/bucket",
-      "Description": "S3 bucket to store your access logs",
-      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "ClientId": {
       "Description": "Google OAuth client ID",
@@ -612,20 +606,6 @@ exports[`The Amiable stack matches the snapshot 1`] = `
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
           },
-          {
-            "Key": "access_logs.s3.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "access_logs.s3.bucket",
-            "Value": {
-              "Ref": "AccessLoggingBucket",
-            },
-          },
-          {
-            "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/deploy/amiable/CODE",
-          },
         ],
         "Scheme": "internet-facing",
         "SecurityGroups": [
@@ -1179,7 +1159,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
-      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuAlb5xxPercentageAlarm",
@@ -1205,11 +1184,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
     "AMIAmiable": {
       "Description": "Amazon Machine Image ID for the app amiable. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
-    },
-    "AccessLoggingBucket": {
-      "Default": "/account/services/access-logging/bucket",
-      "Description": "S3 bucket to store your access logs",
-      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "ClientId": {
       "Description": "Google OAuth client ID",
@@ -1889,20 +1863,6 @@ exports[`The Amiable stack matches the snapshot 2`] = `
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
-          },
-          {
-            "Key": "access_logs.s3.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "access_logs.s3.bucket",
-            "Value": {
-              "Ref": "AccessLoggingBucket",
-            },
-          },
-          {
-            "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/deploy/amiable/PROD",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -68,7 +68,6 @@ export class Amiable extends GuStack {
         ],
       },
       applicationLogging: { enabled: true },
-      accessLogging: { enabled: true, prefix: `ELBLogs/${stack}/${app}/${stage}` },
       scaling: { minimumInstances: 1 },
       imageRecipe: "arm64-focal-java11-deploy-infrastructure",
       instanceMetricGranularity: "5Minute"


### PR DESCRIPTION
These logs are currently unused, so let's switch off access logging for now to simplify the clean up needed when making future updates to this feature.