### PR TITLE
Revert "Switch off access logging feature"

### DIFF
--- a/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
+++ b/cdk/lib/amiable/__snapshots__/amiable.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The Amiable stack matches the snapshot 1`] = `
 {
@@ -624,7 +624,7 @@ exports[`The Amiable stack matches the snapshot 1`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/deploy/amiable/CODE",
+            "Value": "application-load-balancer/CODE/deploy/amiable",
           },
         ],
         "Scheme": "internet-facing",
@@ -1903,7 +1903,7 @@ exports[`The Amiable stack matches the snapshot 2`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/deploy/amiable/PROD",
+            "Value": "application-load-balancer/PROD/deploy/amiable",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/amiable/amiable.ts
+++ b/cdk/lib/amiable/amiable.ts
@@ -68,7 +68,7 @@ export class Amiable extends GuStack {
         ],
       },
       applicationLogging: { enabled: true },
-      accessLogging: { enabled: true, prefix: `ELBLogs/${stack}/${app}/${stage}` },
+      accessLogging: { enabled: true, prefix: `application-load-balancer/${this.stage}/${this.stack}/${app}` },
       scaling: { minimumInstances: 1 },
       imageRecipe: "arm64-focal-java11-deploy-infrastructure",
       instanceMetricGranularity: "5Minute"


### PR DESCRIPTION
Reverts guardian/amiable#793

This will be useful to have in place for testing (and having these on will probably be default behaviour for the cdk pattern going forward).

Deployed to CODE and working as expected! The logs are showing up in the right bucket and with the right path.