### PR TITLE
fix(cdk): Remove redundant Jest config

### DIFF
--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -3,6 +3,5 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
-  transformIgnorePatterns: ["node_modules/(?!@guardian/private-infrastructure-config)"],
   setupFilesAfterEnv: ["./jest.setup.js"],
 };


### PR DESCRIPTION
## What does this change?
We're not using https://github.com/guardian/private-infrastructure-config in this repository[^1], therefore the `transformIgnorePatterns` property is redundant and can be removed.

## How to test?
See CI.

[^1]: As evidenced by it [not appearing in a `package.json`](https://github.com/search?q=repo%3Aguardian%2Famiable%20private-infrastructure-config&type=code).