### PR TITLE
Bump AWS SDK to 2.42.26 to fix Netty CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val jacksonOverrides = {
   )
 }
 
-val awsSdkVersion = "2.41.34"
+val awsSdkVersion = "2.42.26"
 
 libraryDependencies ++= Seq(
   jdbc,


### PR DESCRIPTION
## What does this change?

Bumps aws sdk to latest version to fix GHSA-pwqr-wmgm-9rr8 and GHSA-w9fj-cfpg-grvv.